### PR TITLE
Improve coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit =
+    pyramid_oereb/tests/*
+    pyramid_oereb/models.py
+
+[report]
+skip_covered = True

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ tests: $(PYTHON_VENV) $(TESTS_DROP_DB) $(TESTS_SETUP_DB)
 	SQLALCHEMY_URL="postgresql://$(PG_CREDENTIALS)@$($@_POSTGIS_IP):5432/pyramid_oereb_test" ;\
 	export SQLALCHEMY_URL ;\
 	printenv SQLALCHEMY_URL ;\
-	$(VENV_BIN)py.test$(PYTHON_BIN_POSTFIX) -vv --cov pyramid_oereb pyramid_oereb/tests
+	$(VENV_BIN)py.test$(PYTHON_BIN_POSTFIX) -vv --cov-config .coveragerc --cov pyramid_oereb pyramid_oereb/tests
 
 .PHONY: lint
 lint: $(PYTHON_VENV)


### PR DESCRIPTION
I've added a configuration file for the coverage plugin. The tests directory is now excluded from coverage calculation, as well as the generated models.py file.