### PR TITLE
Set PostgreSQL version to 9.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ git-attributes:
 
 
 tests-docker-setup-db:
-	docker run --name $(DOCKER_CONTAINER_PG) -e POSTGRES_PASSWORD=password -d mdillon/postgis
+	docker run --name $(DOCKER_CONTAINER_PG) -e POSTGRES_PASSWORD=password -d mdillon/postgis:9.4-alpine
 	@echo Waiting 10s for server start up...
 	@sleep 10s
 	docker run -i --link $(DOCKER_CONTAINER_PG):postgres --rm postgres sh -c 'PGPASSWORD=password exec psql -h "$$POSTGRES_PORT_5432_TCP_ADDR" -p "$$POSTGRES_PORT_5432_TCP_PORT" -U postgres -w -c "$(PG_CREATE_DB)"'


### PR DESCRIPTION
Change PostgreSQL version for tests to 9.4 which is used in GMF by default.