### PR TITLE
Read database connection only from yaml file

### DIFF
--- a/pyramid_oereb/tests/conftest.py
+++ b/pyramid_oereb/tests/conftest.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
-import os
 import pyramid.testing
 import transaction
 
 from pyramid_oereb import routes
 from pyramid_oereb.lib.adapter import DatabaseAdapter
+from pyramid_oereb.lib.config import parse
 
-DB_URL = os.environ.get('SQLALCHEMY_URL')
+db_url = parse('pyramid_oereb_test.yml', 'pyramid_oereb').get('db_connection')
 adapter = DatabaseAdapter()
 
 

--- a/pyramid_oereb/tests/test_database_adapter.py
+++ b/pyramid_oereb/tests/test_database_adapter.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import os
 import pytest
 from sqlalchemy.exc import ArgumentError
 from sqlalchemy.orm import Session
 
 from pyramid_oereb.lib.adapter import DatabaseAdapter
+from pyramid_oereb.tests.conftest import db_url
 
 __author__ = 'Clemens Rudert'
 __create_date__ = '16.03.17'
@@ -21,18 +21,16 @@ def test_get_connections():
 
 
 def test_add_connection():
-    test_connection_string = os.environ.get('SQLALCHEMY_URL')
     adapter = DatabaseAdapter()
-    adapter.add_connection(test_connection_string)
-    assert isinstance(adapter.get_session(test_connection_string), Session)
+    adapter.add_connection(db_url)
+    assert isinstance(adapter.get_session(db_url), Session)
 
 
 def test_add_existing_connection():
-    test_connection_string = os.environ.get('SQLALCHEMY_URL')
     adapter = DatabaseAdapter()
-    adapter.add_connection(test_connection_string)
+    adapter.add_connection(db_url)
     expected_length = len(adapter.get_connections())
-    adapter.add_connection(test_connection_string)
+    adapter.add_connection(db_url)
     assert len(adapter.get_connections()) == expected_length
 
 

--- a/pyramid_oereb/tests/test_plr_database_source.py
+++ b/pyramid_oereb/tests/test_plr_database_source.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-import os
 import pytest
 
 from pyramid_oereb.lib.adapter import DatabaseAdapter
 from pyramid_oereb.lib.sources.plr import PlrDatabaseSource
 from pyramid_oereb.models import Plr73PublicLawRestriction, Plr116PublicLawRestriction
-from pyramid_oereb.tests.conftest import adapter
+from pyramid_oereb.tests.conftest import adapter, db_url
 
 __author__ = 'Clemens Rudert'
 __create_date__ = '16.03.17'
@@ -17,7 +16,6 @@ __create_date__ = '16.03.17'
     Plr116PublicLawRestriction
 ])
 def test_init(model):
-    db_url = os.environ.get('SQLALCHEMY_URL')
     adapter.add_connection(db_url)
     source = PlrDatabaseSource(adapter, model)
     assert isinstance(source._adapter_, DatabaseAdapter)
@@ -30,7 +28,6 @@ def test_init(model):
     Plr116PublicLawRestriction
 ])
 def test_read(model):
-    db_url = os.environ.get('SQLALCHEMY_URL')
     adapter.add_connection(db_url)
     source = PlrDatabaseSource(adapter, model)
     source.read(db_url)


### PR DESCRIPTION
Adjust tests to use only the database connection from the yaml file instead of yaml file and environment variable.

References https://github.com/camptocamp/pyramid_oereb/issues/26#issuecomment-288991152.