### PR TITLE
Make database scripts available in venv

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,8 @@
 omit =
     pyramid_oereb/tests/*
     pyramid_oereb/models.py
+    pyramid_oereb/standard/create_tables.py
+    pyramid_oereb/standard/drop_tables.py
 
 [html]
 directory = coverage_report

--- a/pyramid_oereb/standard/__init__.py
+++ b/pyramid_oereb/standard/__init__.py
@@ -25,7 +25,7 @@ def create_models_py(configuration_yaml_path, section='pyramid_oereb'):  # pragm
     models_file.close()
 
 
-def create_tables(configuration_yaml_path, section='pyramid_oereb'):
+def _create_tables_(configuration_yaml_path, section='pyramid_oereb'):
     from pyramid_oereb.models import Base
     config = parse(configuration_yaml_path, section)
     engine = create_engine(config.get('db_connection'), echo=True)
@@ -36,7 +36,7 @@ def create_tables(configuration_yaml_path, section='pyramid_oereb'):
     Base.metadata.create_all(engine)
 
 
-def drop_tables(configuration_yaml_path, section='pyramid_oereb'):
+def _drop_tables_(configuration_yaml_path, section='pyramid_oereb'):
     from pyramid_oereb.models import Base
     config = parse(configuration_yaml_path, section)
     engine = create_engine(config.get('db_connection'), echo=True)

--- a/pyramid_oereb/standard/create_tables.py
+++ b/pyramid_oereb/standard/create_tables.py
@@ -1,27 +1,33 @@
 # -*- coding: utf-8 -*-
-import argparse
-from pyramid_oereb.standard import create_tables
+import optparse
+from pyramid_oereb.standard import _create_tables_
+
 
 __author__ = 'Clemens Rudert'
 __create_date__ = '15.03.17'
 
-parser = argparse.ArgumentParser(description='Create all content for the standard database')
-parser.add_argument(
-    '-c',
-    '--configuration',
-    help='The absolute path to the configuration yaml file (standard is: pyramid_oereb.yml).',
-    required=True
-)
-parser.add_argument(
-    '-s',
-    '--section',
-    help='The section which contains configruation (standard is: pyramid_oereb).',
-    required=False
-)
-args = parser.parse_args()
 
-section = 'pyramid_oereb'
-configuration = args.configuration
-if args.section:
-    section = args.section
-create_tables(configuration_yaml_path=configuration, section=section)
+def create_tables():
+    parser = optparse.OptionParser(
+        usage='usage: %prog [options]',
+        description='Create all content for the standard database'
+    )
+    parser.add_option(
+        '-c', '--configuration',
+        dest='configuration',
+        metavar='YAML',
+        type='string',
+        help='The absolute path to the configuration yaml file (standard is: pyramid_oereb.yml).'
+    )
+    parser.add_option(
+        '-s', '--section',
+        dest='section',
+        metavar='SECTION',
+        type='string',
+        default='pyramid_oereb',
+        help='The section which contains configruation (default is: pyramid_oereb).'
+    )
+    options, args = parser.parse_args()
+    if not options.configuration:
+        parser.error('No configuration file set.')
+    _create_tables_(configuration_yaml_path=options.configuration, section=options.section)

--- a/pyramid_oereb/standard/drop_tables.py
+++ b/pyramid_oereb/standard/drop_tables.py
@@ -1,27 +1,32 @@
 # -*- coding: utf-8 -*-
-import argparse
-from pyramid_oereb.standard import drop_tables
+import optparse
+from pyramid_oereb.standard import _drop_tables_
 
 __author__ = 'Clemens Rudert'
 __create_date__ = '15.03.17'
 
-parser = argparse.ArgumentParser(description='Create all content for the standard database')
-parser.add_argument(
-    '-c',
-    '--configuration',
-    help='The absolute path to the configuration yaml file (standard is: pyramid_oereb.yml).',
-    required=True
-)
-parser.add_argument(
-    '-s',
-    '--section',
-    help='The section which contains configruation (standard is: pyramid_oereb).',
-    required=False
-)
-args = parser.parse_args()
 
-section = 'pyramid_oereb'
-configuration = args.configuration
-if args.section:
-    section = args.section
-drop_tables(configuration_yaml_path=configuration, section=section)
+def drop_tables():
+    parser = optparse.OptionParser(
+        usage='usage: %prog [options]',
+        description='Create all content for the standard database'
+    )
+    parser.add_option(
+        '-c', '--configuration',
+        dest='configuration',
+        metavar='YAML',
+        type='string',
+        help='The absolute path to the configuration yaml file (standard is: pyramid_oereb.yml).'
+    )
+    parser.add_option(
+        '-s', '--section',
+        dest='section',
+        metavar='SECTION',
+        type='string',
+        default='pyramid_oereb',
+        help='The section which contains configruation (default is: pyramid_oereb).'
+    )
+    options, args = parser.parse_args()
+    if not options.configuration:
+        parser.error('No configuration file set.')
+    _drop_tables_(configuration_yaml_path=options.configuration, section=options.section)

--- a/pyramid_oereb/tests/test_standard_db_creation.py
+++ b/pyramid_oereb/tests/test_standard_db_creation.py
@@ -7,12 +7,12 @@ __create_date__ = '16.03.17'
 
 @pytest.mark.run(order=1)
 def test_create_standard_db():
-    from pyramid_oereb.standard import create_tables
-    create_tables(configuration_yaml_path='pyramid_oereb_test.yml')
+    from pyramid_oereb.standard import _create_tables_
+    _create_tables_(configuration_yaml_path='pyramid_oereb_test.yml')
 
 
 @pytest.mark.run(order=0)
 def test_drop_tables():
-    from pyramid_oereb.standard import create_tables, drop_tables
-    create_tables(configuration_yaml_path='pyramid_oereb_test.yml')
-    drop_tables(configuration_yaml_path='pyramid_oereb_test.yml')
+    from pyramid_oereb.standard import _create_tables_, _drop_tables_
+    _create_tables_(configuration_yaml_path='pyramid_oereb_test.yml')
+    _drop_tables_(configuration_yaml_path='pyramid_oereb_test.yml')

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup(
     entry_points="""\
     [paste.app_factory]
     main = pyramid_oereb:main
-
+    [console_scripts]
+    create_tables = pyramid_oereb.standard.create_tables:create_tables
+    drop_tables = pyramid_oereb.standard.drop_tables:drop_tables
     """,
 )


### PR DESCRIPTION
The scripts create_tables and drop_tables are now available as console scripts within the virtual environment. This step is necessary because the scripts interrupted the server start-up.