### PR TITLE
Improve database setup with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,7 @@ git-attributes:
 
 tests-docker-setup-db:
 	docker run --name $(DOCKER_CONTAINER_PG) -e POSTGRES_PASSWORD=$(PG_PASSWORD) -d mdillon/postgis:9.4-alpine
-	@echo Waiting 10s for server start up...
-	@sleep 10s
+	bash wait-for-db.sh $(DOCKER_CONTAINER_PG) $(PG_PASSWORD) $(PG_USER)
 	docker run -i --link $(DOCKER_CONTAINER_PG):postgres --rm postgres sh -c 'PGPASSWORD=$(PG_PASSWORD) exec psql -h "$$POSTGRES_PORT_5432_TCP_ADDR" -p "$$POSTGRES_PORT_5432_TCP_PORT" -U $(PG_USER) -w -c "$(PG_CREATE_DB)"'
 	docker run -i --link $(DOCKER_CONTAINER_PG):postgres --rm postgres sh -c 'PGPASSWORD=$(PG_PASSWORD) exec psql -h "$$POSTGRES_PORT_5432_TCP_ADDR" -p "$$POSTGRES_PORT_5432_TCP_PORT" -d pyramid_oereb_test -U $(PG_USER) -w -c "$(PG_CREATE_EXT)"'
 	docker run -i --link $(DOCKER_CONTAINER_PG):postgres --rm postgres sh -c 'PGPASSWORD=$(PG_PASSWORD) exec psql -h "$$POSTGRES_PORT_5432_TCP_ADDR" -p "$$POSTGRES_PORT_5432_TCP_PORT" -d pyramid_oereb_test -U $(PG_USER) -w -c "$(PG_CREATE_SCHEMA)"'

--- a/wait-for-db.sh
+++ b/wait-for-db.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# wait-for-db.sh
+
+set -e
+
+counter=0
+
+docker_container="$1"
+pg_password="$2"
+pg_user="$3"
+
+cmd="PGPASSWORD=$pg_password exec psql -h \"\$POSTGRES_PORT_5432_TCP_ADDR\" -p \"\$POSTGRES_PORT_5432_TCP_PORT\" -U $pg_user -w -c \"\l\""
+
+echo -n "Waiting for database to be ready"
+until docker run -i --link "$docker_container":postgres --rm postgres sh -c "$cmd" > /dev/null 2>&1; do
+  echo -n "."
+  sleep 1
+  counter=$((counter+1))
+  if [ $counter -eq 60 ]
+  then
+    echo $'\nConnection to database failed: timeout.'
+    exit 1
+  fi
+done
+
+echo $'\nDatabase is ready. Continue with setup...'


### PR DESCRIPTION
Add a script to wait until the database is ready instead of hard coded 10 seconds. Additionally a timeout error is returned after waiting for more than 60 seconds. These changes are only related to the setup using docker.