### PR TITLE
Fix documentation build process

### DIFF
--- a/doc/source/api.rst.mako
+++ b/doc/source/api.rst.mako
@@ -4,9 +4,10 @@ API
 ===
 
 <%!
-import glob, inspect, re, sys
+import glob, inspect, re, sys, pyramid_oereb
 %>
 <%
+reload(pyramid_oereb)
 modules = [m for m in sys.modules.keys() if m.startswith('pyramid_oereb')]
 files = glob.glob('../../pyramid_oereb/*.py')
 files += glob.glob('../../pyramid_oereb/*/*.py')


### PR DESCRIPTION
The documentation build process fails because of deleted modules from earlier versions, that are still registered in sys.modules.

Try to reload the pyramid_oereb module on each build to remove deleted modules.