### PR TITLE
Add flag to skip schema creation

### DIFF
--- a/pyramid_oereb/standard/__init__.py
+++ b/pyramid_oereb/standard/__init__.py
@@ -63,8 +63,7 @@ def _create_all_standard_models_by_yaml_(configuration_yaml_path, section='pyram
     Args:
         configuration_yaml_path (str): The absolute path to the yaml file which contains the plr
             definitions.
-        section (str): The section in yaml file where the plrs are configured in. Standard is
-            'pyramid
+        section (str): The section in yaml file where the plrs are configured in. Default is 'pyramid_oereb'.
     """
     config = parse(configuration_yaml_path, section)
     absolute_path = AssetResolver('pyramid_oereb.standard.models').resolve('').abspath()
@@ -77,7 +76,8 @@ def _create_all_standard_models_by_yaml_(configuration_yaml_path, section='pyram
             )
 
 
-def _create_tables_from_standard_configuration_(configuration_yaml_path, section, tables_only):
+def _create_tables_from_standard_configuration_(configuration_yaml_path, section='pyramid_oereb',
+                                                tables_only=False):
     """
     Creates all schemas which are defined in the passed yaml file: <section>.<plrs>.[<plr>.<code>]. The code
     must be camel case. It will be transformed to snake case and used as schema name.
@@ -87,9 +87,8 @@ def _create_tables_from_standard_configuration_(configuration_yaml_path, section
     Args:
         configuration_yaml_path (str): The absolute path to the yaml file which contains the plr
             definitions.
-        section (str): The section in yaml file where the plrs are configured in. Standard is
-            'pyramid
-        tables_only (bool): True to skip creation of schema.
+        section (str): The section in yaml file where the plrs are configured in. Default is 'pyramid_oereb'.
+        tables_only (bool): True to skip creation of schema. Default is False.
     """
     config = parse(configuration_yaml_path, section)
     main_schema_engine = create_engine(config.get('app_schema').get('db_connection'), echo=True)
@@ -136,8 +135,7 @@ def _drop_tables_from_standard_configuration_(configuration_yaml_path, section='
     Args:
         configuration_yaml_path (str): The absolute path to the yaml file which contains the plr
             definitions.
-        section (str): The section in yaml file where the plrs are configured in. Standard is
-            'pyramid
+        section (str): The section in yaml file where the plrs are configured in. Default is 'pyramid_oereb'.
     """
     config = parse(configuration_yaml_path, section)
     main_schema_engine = create_engine(config.get('app_schema').get('db_connection'), echo=True)
@@ -167,7 +165,6 @@ def _create_standard_yaml_config_(name='pyramid_oereb_standard.yml',
         (str): The name of the new file. Default
         database (str): The database connection string.Default:
             'postgresql://postgres:password@localhost/pyramid_oereb'
-
     """
 
     # File names

--- a/pyramid_oereb/standard/create_tables.py
+++ b/pyramid_oereb/standard/create_tables.py
@@ -14,15 +14,16 @@ logging.basicConfig()
 log = logging.getLogger('pyramid_oereb')
 
 
-def _create_theme_tables(configuration_yaml_path, section, theme, tables_only):
+def _create_theme_tables(configuration_yaml_path, theme, section='pyramid_oereb', tables_only=False):
     """
     Create all tables defined in the specified module.
 
     Args:
         configuration_yaml_path (str): Path to the configuration file.
-        section (str): Section within the specified configuration file used for pyramid_oereb.
         theme (str): Code of the theme to create the tables for.
-        tables_only (bool): True to skip creation of schema.
+        section (str): Section within the specified configuration file used for pyramid_oereb. Default is
+            'pyramid_oereb'.
+        tables_only (bool): True to skip creation of schema. Default is False.
     """
 
     # Parse themes from configuration
@@ -92,7 +93,7 @@ def create_standard_tables():
         metavar='SECTION',
         type='string',
         default='pyramid_oereb',
-        help='The section which contains configruation (default is: pyramid_oereb).'
+        help='The section which contains configuration (default is: pyramid_oereb).'
     )
     parser.add_option(
         '-T', '--tables-only',
@@ -105,7 +106,7 @@ def create_standard_tables():
     if not options.configuration:
         parser.error('No configuration file set.')
     _create_tables_from_standard_configuration_(
-        configuration_yaml_path=options.configuration,
+        options.configuration,
         section=options.section,
         tables_only=options.tables_only
     )
@@ -129,7 +130,7 @@ def create_theme_tables():
         metavar='SECTION',
         type='string',
         default='pyramid_oereb',
-        help='The section which contains configruation (default is: pyramid_oereb).'
+        help='The section which contains configuration (default is: pyramid_oereb).'
     )
     parser.add_option(
         '-t', '--theme',
@@ -152,9 +153,9 @@ def create_theme_tables():
         parser.error('No theme code defined.')
     try:
         _create_theme_tables(
-            configuration_yaml_path=options.configuration,
+            options.configuration,
+            options.theme,
             section=options.section,
-            theme=options.theme,
             tables_only=options.tables_only
         )
     except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,8 +161,6 @@ class MockRequest(DummyRequest):
 
 
 # Set up test database
-_create_tables_from_standard_configuration_(
-    configuration_yaml_path=pyramid_oereb_test_yml, section='pyramid_oereb', tables_only=False
-)
+_create_tables_from_standard_configuration_(pyramid_oereb_test_yml)
 dummy_data = DummyData(config())
 dummy_data.init()

--- a/tests/test_standard_db_creation.py
+++ b/tests/test_standard_db_creation.py
@@ -8,15 +8,11 @@ from tests.conftest import pyramid_oereb_test_yml
 def test_create_standard_db():
     assert pyramid_oereb_test_yml is not None
     from pyramid_oereb.standard import _create_tables_from_standard_configuration_
-    _create_tables_from_standard_configuration_(
-        configuration_yaml_path=pyramid_oereb_test_yml, section='pyramid_oereb', tables_only=False
-    )
+    _create_tables_from_standard_configuration_(pyramid_oereb_test_yml)
 
 
 @pytest.mark.run(order=-2)
 def test_drop_tables():
     assert pyramid_oereb_test_yml is not None
     from pyramid_oereb.standard import _drop_tables_from_standard_configuration_
-    _drop_tables_from_standard_configuration_(
-        configuration_yaml_path=pyramid_oereb_test_yml
-    )
+    _drop_tables_from_standard_configuration_(pyramid_oereb_test_yml)


### PR DESCRIPTION
- Create schema only if it doesn't exist.
- Add flag to skip schema creation.
   For example, if the user has no permission to create a schema, `CREATE SCHEMA IF NOT EXISTS ...` will fail, even if the schema is already existent.