### PR TITLE
Remove some not more used global values

### DIFF
--- a/pyramid_oereb/__init__.py
+++ b/pyramid_oereb/__init__.py
@@ -22,15 +22,8 @@ log = logging.getLogger('pyramid_oereb')
 route_prefix = None
 # initially instantiate database adapter for global session handling
 database_adapter = DatabaseAdapter()
-plr_cadastre_authority = None
-real_estate_reader = None
-municipality_reader = None
-extract_reader = None
-plr_sources = None
 app_schema_name = None
 srid = None
-default_lang = None
-geometry_types = None
 
 
 def main(global_config, **settings):
@@ -55,8 +48,7 @@ def includeme(config):
         config (Configurator): The pyramid apps config object
     """
 
-    global route_prefix, real_estate_reader, municipality_reader, extract_reader, \
-        plr_sources, plr_cadastre_authority, app_schema_name, srid, default_lang
+    global route_prefix, app_schema_name, srid
 
     # Set route prefix
     route_prefix = config.route_prefix
@@ -77,7 +69,6 @@ def includeme(config):
     logos = Config.get_logo_config()
     app_schema_name = Config.get('app_schema').get('name')
     srid = Config.get('srid')
-    default_lang = Config.get('default_language')
 
     plr_cadastre_authority = Config.get_plr_cadastre_authority()
 


### PR DESCRIPTION
app_schema_name and srid are use in file "pyramid_oereb/standard/models/land_use_plans.py"

And the Config seem not available in these "standard/models/*" files. Have you an idea to remove these both global values ?