### PR TITLE
Fix has_data value

### DIFF
--- a/pyramid_oereb/standard/sources/plr.py
+++ b/pyramid_oereb/standard/sources/plr.py
@@ -403,7 +403,7 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
 
                 if session.query(self._model_).count() == 0:
                     # We can stop here already because there are no items in the database
-                    self.records = [EmptyPlrRecord(self._theme_record, has_data=False)]
+                    self.records = [EmptyPlrRecord(self._theme_record, has_data=True)]
 
                 else:
 

--- a/tests/webservice/test_getextractbyid.py
+++ b/tests/webservice/test_getextractbyid.py
@@ -197,12 +197,15 @@ def test_return_json(topics):
     if topics == 'ALL':
         assert len(real_estate.get('RestrictionOnLandownership')) == 6
         assert len(extract.get('ConcernedTheme')) == 3
-        assert len(extract.get('ThemeWithoutData')) > 0
+        assert len(extract.get('NotConcernedTheme')) == 14
+        assert len(extract.get('ThemeWithoutData')) == 0
     if topics == 'ALL_FEDERAL':
         assert len(real_estate.get('RestrictionOnLandownership')) == 1
         assert len(extract.get('ConcernedTheme')) == 1
-        assert len(extract.get('ThemeWithoutData')) > 0
+        assert len(extract.get('NotConcernedTheme')) == 9
+        assert len(extract.get('ThemeWithoutData')) == 0
     if topics == 'ContaminatedSites,RailwaysProjectPlanningZones':
         assert len(real_estate.get('RestrictionOnLandownership')) == 1
         assert len(extract.get('ConcernedTheme')) == 1
-        assert len(extract.get('ThemeWithoutData')) > 0
+        assert len(extract.get('NotConcernedTheme')) == 1
+        assert len(extract.get('ThemeWithoutData')) == 0


### PR DESCRIPTION
The parameter `has_data` signals, if the `EmptyPlrRecord` stands for a "not concerned theme" or a "theme without data".

It has to be set `True` in line 406. This means, the topic is available but doesn't intersect the real estate. So it's listed in the `not_concerned_theme` list.

Line 427 is for unavailable topics, listed in `theme_without_data`.