### PR TITLE
Add PyCharm project settings to .gitignore again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ __pycache__/
 /test-db/12-create.sql
 /test-db/13-fill.sql
 /docker/logo_*.png
+
+# PyCharm IDE
+/.idea/


### PR DESCRIPTION
The folder ".idea" is created and used by PyCharm to store project related settings.

It would be nice to have it added to .gitignore again :wink: 