### PR TITLE
Including OtherLegendDataSource to config and templates

### DIFF
--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -87,12 +87,13 @@ templates:
                             Information: !string #/definitions/MultilingualMText
                                 default: ''
                     OtherLegend: !datasource
+                        default: []
                         attributes:
                             TypeCode: !string #/definitions/RestrictiontypeCode
                                 default: ''
                             SymbolRef: !string
                                 default: ''
-                            Information: !string #/definitions/MultilingualMText
+                            LegendText: !string #/definitions/MultilingualMText
                                 default: ''
                     Geom_Type: !string {}
                     Theme_Code: !string

--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -86,6 +86,14 @@ templates:
                                 default: ''
                             Information: !string #/definitions/MultilingualMText
                                 default: ''
+                    OtherLegend: !datasource
+                        attributes:
+                            TypeCode: !string #/definitions/RestrictiontypeCode
+                                default: ''
+                            SymbolRef: !string
+                                default: ''
+                            Information: !string #/definitions/MultilingualMText
+                                default: ''
                     Geom_Type: !string {}
                     Theme_Code: !string
                         default: ''
@@ -312,6 +320,12 @@ templates:
                     Legend: datasource
                 outputMapper:
                     jrDataSource: LegendDataSource
+            - !createDataSource
+                processors: []
+                inputMapper:
+                    OtherLegend: datasource
+                outputMapper:
+                    jrDataSource: OtherLegendDataSource
             - !createDataSource
                 processors: []
                 inputMapper:

--- a/print/print-apps/oereb/topicotherlegend.jrxml
+++ b/print/print-apps/oereb/topicotherlegend.jrxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topicmapboxlegend" pageWidth="299" pageHeight="20" columnWidth="273" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
+	<field name="SymbolRef" class="java.lang.String"/>
+	<field name="Information" class="java.lang.String"/>
+	<detail>
+		<band height="17" splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<image onErrorType="Blank">
+				<reportElement x="0" y="1" width="17" height="10" uuid="b9ef005c-0354-4c25-92dc-0121e89d814c">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				</reportElement>
+				<imageExpression><![CDATA[$F{SymbolRef}]]></imageExpression>
+			</image>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement x="27" y="0" width="272" height="17" uuid="5f9a91b3-6ee9-4982-a8db-35245b462c2a">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<textElement verticalAlignment="Top">
+					<font fontName="Cadastra"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{Information}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>

--- a/print/print-apps/oereb/topicotherlegend.jrxml
+++ b/print/print-apps/oereb/topicotherlegend.jrxml
@@ -3,7 +3,7 @@
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="topicmapboxlegend" pageWidth="299" pageHeight="20" columnWidth="273" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="6477891d-f5c5-456f-a115-e91b2a2768c6">
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
 	<field name="SymbolRef" class="java.lang.String"/>
-	<field name="Information" class="java.lang.String"/>
+	<field name="LegendText" class="java.lang.String"/>
 	<detail>
 		<band height="17" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
@@ -25,7 +25,7 @@
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{Information}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{LegendText}]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/print/print-apps/oereb/topicpage.jrxml
+++ b/print/print-apps/oereb/topicpage.jrxml
@@ -19,7 +19,7 @@
 			<![CDATA[]]>
 		</queryString>
 		<field name="SymbolRef" class="java.lang.String"/>
-		<field name="Information" class="java.lang.String"/>
+		<field name="LegendText" class="java.lang.String"/>
 	</subDataset>
 	<subDataset name="LegalBasesDataSource" uuid="9a5d3c62-005a-4a40-baa8-4f42f0ef271a">
 		<queryString>

--- a/print/print-apps/oereb/topicpage.jrxml
+++ b/print/print-apps/oereb/topicpage.jrxml
@@ -14,6 +14,13 @@
 		<field name="Information" class="java.lang.String"/>
 		<field name="PartInPercent" class="java.lang.Double"/>
 	</subDataset>
+	<subDataset name="OtherLegendDataSource" uuid="9a5d3c62-005a-4a40-baa8-4f42f0ef271a">
+		<queryString>
+			<![CDATA[]]>
+		</queryString>
+		<field name="SymbolRef" class="java.lang.String"/>
+		<field name="Information" class="java.lang.String"/>
+	</subDataset>
 	<subDataset name="LegalBasesDataSource" uuid="9a5d3c62-005a-4a40-baa8-4f42f0ef271a">
 		<queryString>
 			<![CDATA[]]>
@@ -76,6 +83,7 @@
 	<field name="ResponsibleOffice_OfficeAtWeb" class="java.lang.String"/>
 	<field name="LegalProvisionsDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<field name="LegendDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+	<field name="OtherLegendDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<field name="ReferenceDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<field name="ArticleDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<variable name="V_CURRENT_PAGE_NUMBER" class="java.lang.Integer" resetType="Page" calculation="Sum">
@@ -307,6 +315,13 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$R{BBOXLegendLabel}]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement stretchType="RelativeToTallestObject" x="193" y="0" width="299" height="17" uuid="f88a6ee0-42e5-4d2c-b1ab-9abb4f950664">
+					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				</reportElement>
+				<dataSourceExpression><![CDATA[$F{OtherLegendDataSource}]]></dataSourceExpression>
+				<subreportExpression><![CDATA["topicotherlegend.jasper"]]></subreportExpression>
+			</subreport>
 		</band>
 		<band height="19">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -120,16 +120,15 @@ class Renderer(JsonRenderer):
 
             # Legend of  other visible restriction objects in the topic map
             restriction_on_landownership['OtherLegend'] = restriction_on_landownership['Map'].get(
-                'OtherLegend', '')
+                'OtherLegend', [])
             if restriction_on_landownership['OtherLegend'] != '':
                 for legend_item in restriction_on_landownership['OtherLegend']:
                     self._multilingual_text(legend_item, 'LegendText')
 
             for legend_entry in restriction_on_landownership['OtherLegend']:
-                if legend_entry != '':
-                    for element in legend_entry.keys():
-                        if element not in ['LegendText', 'SymbolRef', 'TypeCode']:
-                            del legend_entry[element]
+                for element in legend_entry.keys():
+                    if element not in ['LegendText', 'SymbolRef', 'TypeCode']:
+                        del legend_entry[element]
 
             del restriction_on_landownership['Map']  # /definitions/Map
 

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -121,9 +121,8 @@ class Renderer(JsonRenderer):
             # Legend of  other visible restriction objects in the topic map
             restriction_on_landownership['OtherLegend'] = restriction_on_landownership['Map'].get(
                 'OtherLegend', [])
-            if restriction_on_landownership['OtherLegend']:
-                for legend_item in restriction_on_landownership['OtherLegend']:
-                    self._multilingual_text(legend_item, 'LegendText')
+            for legend_item in restriction_on_landownership['OtherLegend']:
+                self._multilingual_text(legend_item, 'LegendText')
 
             for legend_entry in restriction_on_landownership['OtherLegend']:
                 for element in legend_entry.keys():

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -63,7 +63,6 @@ class Renderer(JsonRenderer):
             self.lang = self.default_lang
 
         extract_dict = self._render(value[0], value[1])
-
         for attr_name in ['NotConcernedTheme', 'ThemeWithoutData', 'ConcernedTheme']:
             for theme in extract_dict[attr_name]:
                 self._localised_text(theme, 'Text')
@@ -249,7 +248,7 @@ class Renderer(JsonRenderer):
 
         extract_dict['RealEstate_RestrictionOnLandownership'] = restrictions
         # End one restriction entry per theme
-        
+
         for item in extract_dict.get('ExclusionOfLiability', []):
             self._multilingual_text(item, 'Title')
             self._multilingual_text(item, 'Content')

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -126,7 +126,6 @@ class Renderer(JsonRenderer):
 
             for legend_entry in restriction_on_landownership['OtherLegend']:
                 if legend_entry != '':
-                    other_legend = []
                     for element in legend_entry.keys():
                         if not element in ['LegendText', 'SymbolRef', 'TypeCode']:
                             del legend_entry[element]

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -121,7 +121,7 @@ class Renderer(JsonRenderer):
             # Legend of  other visible restriction objects in the topic map
             restriction_on_landownership['OtherLegend'] = restriction_on_landownership['Map'].get(
                 'OtherLegend', [])
-            if restriction_on_landownership['OtherLegend'] != '':
+            if restriction_on_landownership['OtherLegend']:
                 for legend_item in restriction_on_landownership['OtherLegend']:
                     self._multilingual_text(legend_item, 'LegendText')
 

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -63,6 +63,7 @@ class Renderer(JsonRenderer):
             self.lang = self.default_lang
 
         extract_dict = self._render(value[0], value[1])
+
         for attr_name in ['NotConcernedTheme', 'ThemeWithoutData', 'ConcernedTheme']:
             for theme in extract_dict[attr_name]:
                 self._localised_text(theme, 'Text')
@@ -117,6 +118,20 @@ class Renderer(JsonRenderer):
             }
             restriction_on_landownership['legend'] = restriction_on_landownership['Map'].get(
                 'LegendAtWeb', '')
+
+            # Legend of  other visible restriction objects in the topic map
+            restriction_on_landownership['OtherLegend'] = restriction_on_landownership['Map'].get('OtherLegend','')
+            if restriction_on_landownership['OtherLegend'] != '':
+                for legend_item in restriction_on_landownership['OtherLegend']:
+                    self._multilingual_text(legend_item, 'LegendText')
+
+            for legend_entry in restriction_on_landownership['OtherLegend']:
+                if legend_entry != '':
+                    other_legend = []
+                    for element in legend_entry.keys():
+                        if not element in ['LegendText', 'SymbolRef', 'TypeCode']:
+                            del legend_entry[element]
+
             del restriction_on_landownership['Map']  # /definitions/Map
 
             for item in restriction_on_landownership.get('Geometry', []):
@@ -234,7 +249,7 @@ class Renderer(JsonRenderer):
 
         extract_dict['RealEstate_RestrictionOnLandownership'] = restrictions
         # End one restriction entry per theme
-
+        
         for item in extract_dict.get('ExclusionOfLiability', []):
             self._multilingual_text(item, 'Title')
             self._multilingual_text(item, 'Content')

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -119,7 +119,8 @@ class Renderer(JsonRenderer):
                 'LegendAtWeb', '')
 
             # Legend of  other visible restriction objects in the topic map
-            restriction_on_landownership['OtherLegend'] = restriction_on_landownership['Map'].get('OtherLegend','')
+            restriction_on_landownership['OtherLegend'] = restriction_on_landownership['Map'].get(
+                'OtherLegend', '')
             if restriction_on_landownership['OtherLegend'] != '':
                 for legend_item in restriction_on_landownership['OtherLegend']:
                     self._multilingual_text(legend_item, 'LegendText')
@@ -127,7 +128,7 @@ class Renderer(JsonRenderer):
             for legend_entry in restriction_on_landownership['OtherLegend']:
                 if legend_entry != '':
                     for element in legend_entry.keys():
-                        if not element in ['LegendText', 'SymbolRef', 'TypeCode']:
+                        if element not in ['LegendText', 'SymbolRef', 'TypeCode']:
                             del legend_entry[element]
 
             del restriction_on_landownership['Map']  # /definitions/Map


### PR DESCRIPTION
Adds the mandatory 'Other legend' to the PDF extract.
Needs to be completed in the mapfish_print proxy script

- [x] Processing OtherLegend from 
```
'RestrictionOnLandownership': [{
        'Map': {
            'OtherLegend': [{
                'Theme': {
                    'Text': {
                        'Text': "Plan d'affectation",
                        'Language': 'fr'
                    },
                    'Code': 'LandUsePlans'
                },
                'TypeCodelist': u 'https://sitnssl.ne.ch/ogc-pyramid-oereb/wms?SERVICE=WMS&REQUEST=GetStyles&VERSION=1.1.1&LAYERS=r73_affectations_primaires',
                'LegendText': [{
                    'Text': u 'zone industrielle',
                    'Language': 'fr'
                }],
                'SymbolRef': 'http://localhost:6543/oereb/image/symbol/LandUsePlans?TEXT=eyJmciI6ICJ6b25lIGluZHVzdHJpZWxsZSJ9&CODE=1205',
            }],
        }
    }],
```
- [x] Add OtherLegendDataSource to config.yml
- [x] Add OtherLegendSupreport to topicpage.jrxml