### PR TITLE
OEREBlexSource: Add checks for mandatory attributes and extend configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __pycache__/
 
 # Standard configuration
 /pyramid_oereb_standard.yml
+/pyramid_oereb/standard/pyramid_oereb.yml
 /logo_*.png
 
 # Generated files

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ install: $(PYTHON_VENV)
 	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install --requirement $(REQUIREMENTS)
 	touch $@
 
-.venv/install-timestamp: .venv/timestamp setup.py $(REQUIREMENTS)
+.venv/install-timestamp: .venv/timestamp setup.py requirements.txt
 	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install --requirement requirements.txt
 	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install --editable .
 	touch $@

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -88,7 +88,9 @@ class OEREBlexSource(Base):
 
         # Cancel if document contains no files
         if len(document.files) == 0:
-            log.warning('Document "{0}" has been skipped because of missing file.'.format(document.title))
+            log.warning('Document with OEREBlex ID {0} has been skipped because of missing file.'.format(
+                document.id
+            ))
             return []
 
         # Check mandatory attributes

--- a/pyramid_oereb/contrib/sources/document.py
+++ b/pyramid_oereb/contrib/sources/document.py
@@ -53,6 +53,8 @@ class OEREBlexSource(Base):
         auth = kwargs.get('auth')
         if isinstance(auth, dict) and 'username' in auth and 'password' in auth:
             self._auth = HTTPBasicAuth(auth.get('username'), auth.get('password'))
+        else:
+            self._auth = None
 
         self._language = str(kwargs.get('language')).lower()
         assert self._language is not None and len(self._language) == 2

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -132,7 +132,13 @@ pyramid_oereb:
     canton: BL
     # Mapping for other optional attributes
     mapping:
-      municipality: subtype
+      official_number: number
+      abbreviation: abbreviation
+    # Handle related decree also as main document
+    # By default a related decree will be added as reference of the type "legal provision" to the main
+    # document. Set this flag to true, if you want the related decree to be added as additional legal
+    # provision directly to the public law restriction. This might have an impact on client side rendering.
+    related_decree_as_main: false
     # Proxy to be used for web requests
     # proxy:
     #   http:

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -126,6 +126,10 @@ pyramid_oereb:
   oereblex:
     # OEREBlex host
     host: https://oereblex.bl.ch
+    # geoLink schema version
+    # version: 1.1.0
+    # Pass schema version in URL
+    # pass_version: true
     # Language of returned values
     language: de
     # Value for canton attribute
@@ -143,6 +147,10 @@ pyramid_oereb:
     # proxy:
     #   http:
     #   https:
+    # Credentials for basic authentication
+    # auth:
+    #   username:
+    #   password:
 
   # Defines the information of the oereb cadastre providing authority. Please change this to your data. This
   # will be directly used for producing the extract output.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ pyreproj==1.0.0
 lxml==4.1.1
 generateDS==2.28.2
 requests==2.18.4
-geolink-formatter==1.1.2
+geolink-formatter==1.3.0
 pyconizer==0.1.4

--- a/tests/adapter/test_file.py
+++ b/tests/adapter/test_file.py
@@ -26,7 +26,7 @@ def test_ls():
     file_adapter = FileAdapter(base_path)
     dir_list = file_adapter.ls()
     assert isinstance(dir_list, list)
-    assert len(dir_list) == 4
+    assert len(dir_list) == 5
     file_found = False
     dir_found = False
     for entry in dir_list:

--- a/tests/resources/geolink.xml
+++ b/tests/resources/geolink.xml
@@ -11,6 +11,14 @@
     </document>
     <document authority='Landeskanzlei'
               authority_url='https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei'
+              category='related' doctype='decree' enactment_date='1974-08-27' federal_level='Kanton' id='101'
+              subtype='Reigoldswil' title='GWSZ Weihermatt- und Habermattquellen'
+              type='Grundwasserschutzzonen'>
+        <file category='main' href='/api/attachments/314' title='1974_08_27_2858_addition.pdf'></file>
+
+    </document>
+    <document authority='Landeskanzlei'
+              authority_url='https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei'
               category='related' decree_date='1998-01-13' doctype='edict' enactment_date='2016-01-01'
               federal_level='Kanton' id='11'
               title='Verordnung über die Wasserversorgung sowie die Nutzung und den Schutz des Grundwassers'>

--- a/tests/resources/geolink_v1.0.0.xml
+++ b/tests/resources/geolink_v1.0.0.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geolinks>
+    <document authority='Landeskanzlei'
+              authority_url='https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei'
+              category='main' doctype='decree' enactment_date='1974-08-27' federal_level='Kanton' id='100'
+              subtype='Reigoldswil' title='GWSZ Weihermatt- und Habermattquellen'
+              type='Grundwasserschutzzonen' cycle='test'>
+        <file category='main' href='/api/attachments/313' title='1974_08_27_2858.pdf'></file>
+        <file category='additional' href='/api/attachments/145' title='BL_54_WZ_00_00.pdf'></file>
+
+    </document>
+    <document authority='Landeskanzlei'
+              authority_url='https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei'
+              category='related' doctype='decree' enactment_date='1974-08-27' federal_level='Kanton' id='101'
+              subtype='Reigoldswil' title='GWSZ Weihermatt- und Habermattquellen'
+              type='Grundwasserschutzzonen'>
+        <file category='main' href='/api/attachments/314' title='1974_08_27_2858_addition.pdf'></file>
+
+    </document>
+    <document authority='Landeskanzlei'
+              authority_url='https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei'
+              category='related' decree_date='1998-01-13' doctype='edict' enactment_date='2016-01-01'
+              federal_level='Kanton' id='11'
+              title='Verordnung über die Wasserversorgung sowie die Nutzung und den Schutz des Grundwassers'>
+        <file category='main' href='http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1437?locale=de'
+              title='455.11.pdf'></file>
+
+    </document>
+    <document authority='Bundeskanzlei' authority_url='' category='related' doctype='edict'
+              enactment_date='2017-01-01' federal_level='Bund' id='8'
+              title='Bundesgesetz über den Schutz der Gewässer'>
+        <file category='main' href='http://www.lexfind.ch/dtah/144693/2' title='814.20.de.pdf'></file>
+
+    </document>
+    <document authority='Bundeskanzlei' authority_url='' category='related' doctype='edict'
+              enactment_date='2016-02-02' federal_level='Bund' id='9' title='Gewässerschutzverordnung'>
+        <file category='main' href='http://www.lexfind.ch/dtah/145096/2' title='814.201.de.pdf'></file>
+
+    </document>
+    <document authority='Landeskanzlei'
+              authority_url='https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei'
+              category='related' decree_date='1967-04-03' doctype='edict' enactment_date='2015-01-01'
+              federal_level='Kanton' id='10' title='Gesetz über die Nutzung und den Schutz des Grundwassers'>
+        <file category='main' href='http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1122?locale=de'
+              title='454.pdf'></file>
+
+    </document>
+</geolinks>

--- a/tests/resources/geolink_v1.1.0.xml
+++ b/tests/resources/geolink_v1.1.0.xml
@@ -4,7 +4,7 @@
               authority_url='https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei'
               category='main' doctype='decree' enactment_date='1974-08-27' federal_level='Kanton' id='100'
               subtype='Reigoldswil' title='GWSZ Weihermatt- und Habermattquellen'
-              type='Grundwasserschutzzonen'>
+              type='Grundwasserschutzzonen' abbreviation="GWSZ" number="1974_08_27_2858">
         <file category='main' href='/api/attachments/313' title='1974_08_27_2858.pdf'></file>
         <file category='additional' href='/api/attachments/145' title='BL_54_WZ_00_00.pdf'></file>
 


### PR DESCRIPTION
The `OEREBlexSource` is extended

- to check if all mandatory attributes are set, because this isn't handled in the `geolink_formatter` library anymore (since version 1.1.2).
- with the default mapping for the relevant attributes of the new geoLink schema (20171108).
- with a configuration flag to put documents of the category `related` and the doctype `decree` into the list of main documents (directly to the public law restriction) instead of the list of referenced documents. This is useful to avoid referenced legal provisions being listed with the other legal documents (doctype `edict`).