### PR TITLE
Fix legend entry matching

### DIFF
--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -12,18 +12,18 @@ def includeme(config):  # pragma: no cover
     """
 
     # Service for logo images
-    config.add_route('{0}/image/logo'.format(route_prefix), '/image/logo/{logo}.png')
+    config.add_route('{0}/image/logo'.format(route_prefix), '/image/logo/{logo}')
     config.add_view(Logo, attr='get_image', route_name='{0}/image/logo'.format(route_prefix),
                     request_method='GET')
 
     # Service for municipality images
-    config.add_route('{0}/image/municipality'.format(route_prefix), '/image/municipality/{fosnr}.png')
+    config.add_route('{0}/image/municipality'.format(route_prefix), '/image/municipality/{fosnr}')
     config.add_view(Municipality, attr='get_image', route_name='{0}/image/municipality'.format(route_prefix),
                     request_method='GET')
 
     # Service for symbol images
     config.add_route('{0}/image/symbol'.format(route_prefix),
-                     '/image/symbol/{theme_code}/{type_code}.png')
+                     '/image/symbol/{theme_code}/{type_code}')
     config.add_view(Symbol, attr='get_image', route_name='{0}/image/symbol'.format(route_prefix),
                     request_method='GET')
 

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -12,18 +12,18 @@ def includeme(config):  # pragma: no cover
     """
 
     # Service for logo images
-    config.add_route('{0}/image/logo'.format(route_prefix), '/image/logo/{logo}')
+    config.add_route('{0}/image/logo'.format(route_prefix), '/image/logo/{logo}.png')
     config.add_view(Logo, attr='get_image', route_name='{0}/image/logo'.format(route_prefix),
                     request_method='GET')
 
     # Service for municipality images
-    config.add_route('{0}/image/municipality'.format(route_prefix), '/image/municipality/{fosnr}')
+    config.add_route('{0}/image/municipality'.format(route_prefix), '/image/municipality/{fosnr}.png')
     config.add_view(Municipality, attr='get_image', route_name='{0}/image/municipality'.format(route_prefix),
                     request_method='GET')
 
     # Service for symbol images
     config.add_route('{0}/image/symbol'.format(route_prefix),
-                     '/image/symbol/{theme_code}')
+                     '/image/symbol/{theme_code}/{type_code}.png')
     config.add_view(Symbol, attr='get_image', route_name='{0}/image/symbol'.format(route_prefix),
                     request_method='GET')
 

--- a/pyramid_oereb/standard/hook_methods.py
+++ b/pyramid_oereb/standard/hook_methods.py
@@ -102,7 +102,7 @@ def get_symbol(request):
             if symbol:
                 response = request.response
                 response.status_int = 200
-                response.content_type = 'image/png'
+                response.content_type = 'image/*'
                 response.body = base64.b64decode(symbol.encode('ascii'))
                 return response
         raise HTTPNotFound()

--- a/pyramid_oereb/standard/hook_methods.py
+++ b/pyramid_oereb/standard/hook_methods.py
@@ -1,18 +1,16 @@
 # -*- coding: utf-8 -*-
 import base64
 import datetime
-import json
 
 from mako import exceptions
 from mako.template import Template
-from pyramid.httpexceptions import HTTPNotFound, HTTPBadRequest
+from pyramid.httpexceptions import HTTPNotFound
 from pyramid.path import AssetResolver, DottedNameResolver
 from pyramid.response import Response
 from sqlalchemy import cast, Text
 
 from pyramid_oereb import Config, database_adapter, route_prefix
 from pyramid_oereb.lib.records.office import OfficeRecord
-from pyramid_oereb.lib.records.plr import PlrRecord
 
 
 def get_logo(request):

--- a/pyramid_oereb/standard/sources/plr.py
+++ b/pyramid_oereb/standard/sources/plr.py
@@ -297,8 +297,7 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
         )
         symbol = None
         for legend_entry_record in legend_entry_records:
-            if public_law_restriction_from_db.type_code == legend_entry_record.type_code \
-                    and public_law_restriction_from_db.information == legend_entry_record.legend_text:
+            if public_law_restriction_from_db.type_code == legend_entry_record.type_code:
                 symbol = legend_entry_record.symbol
         if symbol is None:
             # TODO: raise real error here when data is correct, emit warning for now

--- a/tests/renderer/test_base.py
+++ b/tests/renderer/test_base.py
@@ -122,7 +122,7 @@ def test_get_symbol_ref(config, theme_code):
                 Base.get_symbol_ref(request, record)
         else:
             ref = Base.get_symbol_ref(request, record)
-            assert ref == 'http://example.com/image/symbol/{}/{}.png'.format(
+            assert ref == 'http://example.com/image/symbol/{}/{}'.format(
                 theme_code,
                 record.type_code
             )

--- a/tests/renderer/test_base.py
+++ b/tests/renderer/test_base.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import base64
-import json
 
 import pytest
 import datetime

--- a/tests/renderer/test_base.py
+++ b/tests/renderer/test_base.py
@@ -124,10 +124,7 @@ def test_get_symbol_ref(config, theme_code):
                 Base.get_symbol_ref(request, record)
         else:
             ref = Base.get_symbol_ref(request, record)
-            assert ref == 'http://example.com/image/symbol/{}?TEXT={}&CODE={}'.format(
+            assert ref == 'http://example.com/image/symbol/{}/{}.png'.format(
                 theme_code,
-                base64.b64encode(
-                    json.dumps(record.legend_text).encode('utf-8')
-                ).decode('ascii').replace('=', '%3D'),
                 record.type_code
             )

--- a/tests/renderer/test_json.py
+++ b/tests/renderer/test_json.py
@@ -130,10 +130,10 @@ def test_render(config, parameter):
                 })
             else:
                 expected.update({
-                    'LogoPLRCadastreRef': u'http://example.com/image/logo/oereb.png',
-                    'FederalLogoRef': u'http://example.com/image/logo/confederation.png',
-                    'CantonalLogoRef': u'http://example.com/image/logo/canton.png',
-                    'MunicipalityLogoRef': u'http://example.com/image/municipality/2829.png'
+                    'LogoPLRCadastreRef': u'http://example.com/image/logo/oereb',
+                    'FederalLogoRef': u'http://example.com/image/logo/confederation',
+                    'CantonalLogoRef': u'http://example.com/image/logo/canton',
+                    'MunicipalityLogoRef': u'http://example.com/image/municipality/2829'
                 })
             assert result == expected
 
@@ -267,7 +267,7 @@ def test_format_plr(config, parameter):
                 })
             else:
                 expected.update({
-                    'SymbolRef': 'http://example.com/image/symbol/{theme}/{code}.png'.format(
+                    'SymbolRef': 'http://example.com/image/symbol/{theme}/{code}'.format(
                         theme='ContaminatedSites',
                         code='test'
                     )
@@ -494,7 +494,7 @@ def test_format_legend_entry(parameter, config):
             })
         else:
             expected.update({
-                'SymbolRef': 'http://example.com/image/symbol/{theme_code}/{code}.png'.format(
+                'SymbolRef': 'http://example.com/image/symbol/{theme_code}/{code}'.format(
                     theme_code='ContaminatedSites',
                     code='type1'
                 )

--- a/tests/renderer/test_json.py
+++ b/tests/renderer/test_json.py
@@ -3,7 +3,6 @@
 import base64
 
 import datetime
-import json
 
 import pytest
 from shapely.geometry import MultiPolygon, Polygon, Point, LineString

--- a/tests/renderer/test_json.py
+++ b/tests/renderer/test_json.py
@@ -131,10 +131,10 @@ def test_render(config, parameter):
                 })
             else:
                 expected.update({
-                    'LogoPLRCadastreRef': u'http://example.com/image/logo/oereb',
-                    'FederalLogoRef': u'http://example.com/image/logo/confederation',
-                    'CantonalLogoRef': u'http://example.com/image/logo/canton',
-                    'MunicipalityLogoRef': u'http://example.com/image/municipality/2829'
+                    'LogoPLRCadastreRef': u'http://example.com/image/logo/oereb.png',
+                    'FederalLogoRef': u'http://example.com/image/logo/confederation.png',
+                    'CantonalLogoRef': u'http://example.com/image/logo/canton.png',
+                    'MunicipalityLogoRef': u'http://example.com/image/municipality/2829.png'
                 })
             assert result == expected
 
@@ -268,11 +268,8 @@ def test_format_plr(config, parameter):
                 })
             else:
                 expected.update({
-                    'SymbolRef': 'http://example.com/image/symbol/{theme}?TEXT={text}&CODE={code}'.format(
+                    'SymbolRef': 'http://example.com/image/symbol/{theme}/{code}.png'.format(
                         theme='ContaminatedSites',
-                        text=base64.b64encode(
-                            json.dumps(legend_entry.legend_text).encode('utf-8')
-                        ).decode('ascii').replace('=', '%3D'),
                         code='test'
                     )
                 })
@@ -498,11 +495,8 @@ def test_format_legend_entry(parameter, config):
             })
         else:
             expected.update({
-                'SymbolRef': 'http://example.com/image/symbol/{theme_code}?TEXT={text}&CODE={code}'.format(
+                'SymbolRef': 'http://example.com/image/symbol/{theme_code}/{code}.png'.format(
                     theme_code='ContaminatedSites',
-                    text=base64.b64encode(
-                        json.dumps(legend_entry.legend_text).encode('utf-8')
-                    ).decode('ascii').replace('=', '%3D'),
                     code='type1'
                 )
             })

--- a/tests/test_hook_methods.py
+++ b/tests/test_hook_methods.py
@@ -61,4 +61,4 @@ def test_get_symbol_ref(config):
     with pyramid_oereb_test_config():
         request = DummyRequest()
         url = urlparse(get_symbol_ref(request, record))
-        assert url.path == '/image/symbol/ContaminatedSites/test.png'
+        assert url.path == '/image/symbol/ContaminatedSites/test'

--- a/tests/test_hook_methods.py
+++ b/tests/test_hook_methods.py
@@ -22,24 +22,10 @@ def test_get_symbol_invalid_theme_code(config):
     assert isinstance(config._config, dict)
     request = DummyRequest()
     request.matchdict.update({
-        'theme_code': 'InvalidThemeCode'
+        'theme_code': 'InvalidThemeCode',
+        'type_code': 'test'
     })
     with pytest.raises(HTTPNotFound):
-        get_symbol(request)
-
-
-@pytest.mark.parametrize('params', [
-    {},
-    {'CODE': 'foo'}
-])
-def test_get_symbol_missing_param(config, params):
-    assert isinstance(config._config, dict)
-    request = DummyRequest()
-    request.matchdict.update({
-        'theme_code': 'ContaminatedSites'
-    })
-    request.params.update(params)
-    with pytest.raises(HTTPBadRequest):
         get_symbol(request)
 
 
@@ -47,11 +33,8 @@ def test_get_symbol_not_found(config):
     assert isinstance(config._config, dict)
     request = DummyRequest()
     request.matchdict.update({
-        'theme_code': 'ContaminatedSites'
-    })
-    request.params.update({
-        'CODE': 'foo',
-        'TEXT': base64.b64encode(json.dumps({'en': 'bar'}).encode('utf-8')).decode('ascii')
+        'theme_code': 'ContaminatedSites',
+        'type_code': 'missing'
     })
     with pytest.raises(HTTPNotFound):
         get_symbol(request)
@@ -61,11 +44,8 @@ def test_get_symbol(config):
     assert isinstance(config._config, dict)
     request = DummyRequest()
     request.matchdict.update({
-        'theme_code': 'ContaminatedSites'
-    })
-    request.params.update({
-        'CODE': 'test',
-        'TEXT': base64.b64encode(json.dumps({'de': 'Test'}).encode('utf-8')).decode('ascii')
+        'theme_code': 'ContaminatedSites',
+        'type_code': 'test'
     })
     response = get_symbol(request)
     assert response.body.decode('utf-8') == '1'
@@ -83,8 +63,4 @@ def test_get_symbol_ref(config):
     with pyramid_oereb_test_config():
         request = DummyRequest()
         url = urlparse(get_symbol_ref(request, record))
-        params = parse_qs(url.query)
-        assert url.path == '/image/symbol/ContaminatedSites'
-        assert params.get('CODE')[0] == 'test'
-        assert params.get('TEXT')[0] == base64.b64encode(json.dumps({'de': 'Test'}).encode('utf-8'))\
-            .decode('ascii')
+        assert url.path == '/image/symbol/ContaminatedSites/test.png'

--- a/tests/test_hook_methods.py
+++ b/tests/test_hook_methods.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-import base64
-import json
 
 import pytest
 
-from pyramid.httpexceptions import HTTPNotFound, HTTPBadRequest
+from pyramid.httpexceptions import HTTPNotFound
 from pyramid.testing import DummyRequest
 from pyramid_oereb.lib.records.image import ImageRecord
 from pyramid_oereb.lib.records.theme import ThemeRecord
@@ -13,9 +11,9 @@ from pyramid_oereb.standard.hook_methods import get_symbol, get_symbol_ref
 from tests.conftest import pyramid_oereb_test_config
 
 try:
-    from urllib.parse import urlparse, parse_qs
+    from urllib.parse import urlparse
 except ImportError:
-    from urlparse import urlparse, parse_qs
+    from urlparse import urlparse
 
 
 def test_get_symbol_invalid_theme_code(config):

--- a/tests/webservice/test_symbol.py
+++ b/tests/webservice/test_symbol.py
@@ -14,11 +14,8 @@ from pyramid_oereb.views.webservice import Symbol
 def test_get_image():
     request = MockRequest()
     request.matchdict.update({
-        'theme_code': 'ContaminatedSites'
-    })
-    request.params.update({
-        'CODE': 'test',
-        'TEXT': base64.b64encode(json.dumps({'de': u'Test'}).encode('utf-8')).decode('ascii')
+        'theme_code': 'ContaminatedSites',
+        'type_code': 'test'
     })
     webservice = Symbol(request)
     result = webservice.get_image()
@@ -32,11 +29,8 @@ def test_get_image():
 def test_get_image_invalid():
     request = MockRequest()
     request.matchdict.update({
-        'theme_code': 'ContaminatedSites'
-    })
-    request.params.update({
-        'CODE': 'notExisting',
-        'TEXT': base64.b64encode(json.dumps({'de': u'Test'}).encode('utf-8')).decode('ascii')
+        'theme_code': 'ContaminatedSites',
+        'type_code': 'notExisting'
     })
     webservice = Symbol(request)
     with pytest.raises(HTTPNotFound):

--- a/tests/webservice/test_symbol.py
+++ b/tests/webservice/test_symbol.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import base64
-import json
 import pytest
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.response import Response


### PR DESCRIPTION
Because of an error in the federal data (no unique information for each type code), the matching of restrictions and legend entries is done by `type_code` **and** `information`/`legend_text`.

As the error in the data is fixed since the beginning of December, the matching can now be done by `type_code` only. This is how it is supposed to be according to the specification.