### PR TITLE
Keep used elements in printed 'other legend'

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -119,15 +119,15 @@ class Renderer(JsonRenderer):
             restriction_on_landownership['legend'] = restriction_on_landownership['Map'].get(
                 'LegendAtWeb', '')
 
-            # Legend of  other visible restriction objects in the topic map
+            # Legend of other visible restriction objects in the topic map
             restriction_on_landownership['OtherLegend'] = restriction_on_landownership['Map'].get(
                 'OtherLegend', [])
             for legend_item in restriction_on_landownership['OtherLegend']:
                 self._multilingual_text(legend_item, 'LegendText')
 
             for legend_entry in restriction_on_landownership['OtherLegend']:
-                for element in ['LegendText', 'SymbolRef', 'TypeCode']:
-                    if element in legend_entry:
+                for element in legend_entry.keys():
+                    if element not in ['LegendText', 'SymbolRef', 'TypeCode']:
                         del legend_entry[element]
 
             del restriction_on_landownership['Map']  # /definitions/Map


### PR DESCRIPTION
Last work on mapfish print other legend handling break this part of the report.
The code was ~right one month ago : https://github.com/camptocamp/pyramid_oereb/commit/afea557d27c2ad9c4d7200789e2e0b2820d671d0#diff-cfb7a95e0585c750deca6eabb5c5119bR132

OtherLegend elements is (before this PR):

````
                "OtherLegend": [
                    {
                        "Theme": {
                            "Code": "LandUsePlans", 
                            "Text": {
                                "Language": "de", 
                                "Text": "Nutzungsplanung kommunal"
                            }
                        }, 
                        "TypeCodelist": "http://models.geo.sz.ch"
                    }, 
                    {
                        "Theme": {
                            "Code": "LandUsePlans", 
                            "Text": {
                                "Language": "de", 
                                "Text": "Nutzungsplanung kommunal"
                            }
                        }, 
                        "TypeCodelist": "http://models.geo.sz.ch"
                    }, 
                    {
                        "Theme": {
                            "Code": "LandUsePlans", 
                            "Text": {
                                "Language": "de", 
                                "Text": "Nutzungsplanung kommunal"
                            }
                        }, 
                        "TypeCodelist": "http://models.geo.sz.ch"
                    }
                ], 
````

With this change it's:

````
                "OtherLegend": [
                    {
                        "LegendText": "weitere Bauzone", 
                        "SymbolRef": "https://map-d.geo.sz.ch/bge_oereb/wsgi/oereb/image/symbol/LandUsePlans?TEXT=eyJkZSI6ICJ3ZWl0ZXJlIEJhdXpvbmUifQ%3D%3D&CODE=199", 
                        "TypeCode": "199"
                    }, 
                    {
                        "LegendText": "Verkehrszone A", 
                        "SymbolRef": "https://map-d.geo.sz.ch/bge_oereb/wsgi/oereb/image/symbol/LandUsePlans?TEXT=eyJkZSI6ICJWZXJrZWhyc3pvbmUgQSJ9&CODE=181", 
                        "TypeCode": "181"
                    }, 
                    {
                        "LegendText": "Gew\u00e4sser", 
                        "SymbolRef": "https://map-d.geo.sz.ch/bge_oereb/wsgi/oereb/image/symbol/LandUsePlans?TEXT=eyJkZSI6ICJHZXdcdTAwZTRzc2VyIn0%3D&CODE=321", 
                        "TypeCode": "321"
                    }
                ], 
````