### PR TITLE
mapfish_print proxy: simplify language usage

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -54,8 +54,8 @@ class Renderer(JsonRenderer):
         if value[1].images:
             raise HTTPBadRequest('With image is not allowed in the print')
 
-        # If language present in request, use that. Otherwise, keep language from base class
         self._request = self.get_request(system)
+        # If language present in request, use that. Otherwise, keep language from base class
         if 'lang' in self._request.GET:
             self._language = self._request.GET.get('lang')
 

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -54,13 +54,10 @@ class Renderer(JsonRenderer):
         if value[1].images:
             raise HTTPBadRequest('With image is not allowed in the print')
 
+        # If language present in request, use that. Otherwise, keep language from base class
         self._request = self.get_request(system)
-
-        self.default_lang = Config.get('default_language')
         if 'lang' in self._request.GET:
-            self.lang = self._request.GET.get('lang')
-        else:
-            self.lang = self.default_lang
+            self._language = self._request.GET.get('lang')
 
         extract_dict = self._render(value[0], value[1])
         for attr_name in ['NotConcernedTheme', 'ThemeWithoutData', 'ConcernedTheme']:
@@ -283,7 +280,7 @@ class Renderer(JsonRenderer):
         spec = {
             'layout': Config.get('print', {})['template_name'],
             'outputFormat': 'pdf',
-            'lang': self.lang,
+            'lang': self._language,
             'attributes': extract_dict,
         }
 
@@ -361,4 +358,4 @@ class Renderer(JsonRenderer):
     def _multilingual_text(self, parent, name):
         if name in parent:
             lang_obj = dict([(e['Language'], e['Text']) for e in parent[name]])
-            parent[name] = lang_obj[self.lang]
+            parent[name] = lang_obj[self._language]


### PR DESCRIPTION
Because the base class already has a _language, and because I could not find a reason for a second attribute about language, I propose that we remove the additional "lang".

This makes the code a bit easier, and also simplifies testing because objects can be reused more easily.