### PR TITLE
Define an order for the Legend entries

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -258,7 +258,10 @@ class Renderer(JsonRenderer):
                 for item in ['Area', 'Length']:
                     if item in legend:
                         legend[item] = int(legend[item])
-            restriction['Legend'] = list(legends.values())
+            # After transformation, get the new legend entries, sorted by TypeCode
+            transformed_legend = list([value for (key, value) in sorted(legends.items())])
+            log.debug("transformed legend: {}".format(transformed_legend))
+            restriction['Legend'] = transformed_legend
 
         extract_dict['RealEstate_RestrictionOnLandownership'] = restrictions
         # End one restriction entry per theme

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -259,8 +259,8 @@ class Renderer(JsonRenderer):
                     if item in legend:
                         legend[item] = int(legend[item])
             # After transformation, get the new legend entries, sorted by TypeCode
-            transformed_legend = list([value for (key, value) in sorted(legends.items())])
-            log.debug("transformed legend: {}".format(transformed_legend))
+            transformed_legend = \
+                list([transformed_entry for (key, transformed_entry) in sorted(legends.items())])
             restriction['Legend'] = transformed_legend
 
         extract_dict['RealEstate_RestrictionOnLandownership'] = restrictions


### PR DESCRIPTION
Current, there is no order defined for the legend entries, so the order of these entries in the print spec depends on the execution environment.
This is not optimal because
-  the report for the identical extract varies according to the user environment, which is confusing for users
-  testing is hard: we can not do straight-forward tests, because we would need to program in the test case the assumption that the order should not matter for the legend entries. See also https://github.com/camptocamp/pyramid_oereb/issues/341.