### PR TITLE
check if the downloaded content is a PDF

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -96,6 +96,10 @@ class Renderer(JsonRenderer):
             for url in pdf_to_join:
                 tmp_file = tempfile.NamedTemporaryFile(suffix='.pdf')
                 result = requests.get(url)
+                content_type = result.headers.get('content-type')
+                log.debug("document url: " + url + " => content_type: " + content_type);
+                if content_type != 'application/pdf':
+                    continue
                 tmp_file.write(result.content)
                 tmp_file.flush()
                 temp_files.append(tmp_file)

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -98,7 +98,9 @@ class Renderer(JsonRenderer):
                 content_type = result.headers.get('content-type')
                 log.debug("document url: " + url + " => content_type: " + content_type)
                 if content_type != 'application/pdf':
-                    log.warn("skipped document inclusion (url: " + url + " ) because content_type: " + content_type)
+                    msg = "Skipped document inclusion (url: '{}') because content_type: '{}'"
+                    fmt = msg.format(url, content_type)
+                    log.warn(fmt)
                     continue
                 tmp_file = tempfile.NamedTemporaryFile(suffix='.pdf')
                 tmp_file.write(result.content)

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -99,8 +99,7 @@ class Renderer(JsonRenderer):
                 log.debug("document url: " + url + " => content_type: " + content_type)
                 if content_type != 'application/pdf':
                     msg = "Skipped document inclusion (url: '{}') because content_type: '{}'"
-                    fmt = msg.format(url, content_type)
-                    log.warn(fmt)
+                    log.warn(msg.format(url, content_type))
                     continue
                 tmp_file = tempfile.NamedTemporaryFile(suffix='.pdf')
                 tmp_file.write(result.content)

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -98,6 +98,7 @@ class Renderer(JsonRenderer):
                 content_type = result.headers.get('content-type')
                 log.debug("document url: " + url + " => content_type: " + content_type)
                 if content_type != 'application/pdf':
+                    log.warn("skipped document inclusion (url: " + url + " ) because content_type: " + content_type)
                     continue
                 tmp_file = tempfile.NamedTemporaryFile(suffix='.pdf')
                 tmp_file.write(result.content)

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -94,12 +94,12 @@ class Renderer(JsonRenderer):
             cmd = ['pdftk', main.name]
             temp_files = [main]
             for url in pdf_to_join:
-                tmp_file = tempfile.NamedTemporaryFile(suffix='.pdf')
                 result = requests.get(url)
                 content_type = result.headers.get('content-type')
                 log.debug("document url: " + url + " => content_type: " + content_type)
                 if content_type != 'application/pdf':
                     continue
+                tmp_file = tempfile.NamedTemporaryFile(suffix='.pdf')
                 tmp_file.write(result.content)
                 tmp_file.flush()
                 temp_files.append(tmp_file)

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -97,7 +97,7 @@ class Renderer(JsonRenderer):
                 tmp_file = tempfile.NamedTemporaryFile(suffix='.pdf')
                 result = requests.get(url)
                 content_type = result.headers.get('content-type')
-                log.debug("document url: " + url + " => content_type: " + content_type);
+                log.debug("document url: " + url + " => content_type: " + content_type)
                 if content_type != 'application/pdf':
                     continue
                 tmp_file.write(result.content)


### PR DESCRIPTION
During our test, it happened that one downloaded file wasn't a PDF, therefore, it was throwing an exception.
Skipping if the content type isn't equal to application/pdf.