### PR TITLE
avoid null glossary entries

### DIFF
--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -136,10 +136,11 @@ class Renderer(Base):
         if isinstance(extract.glossaries, list) and len(extract.glossaries) > 0:
             glossaries = list()
             for gls in extract.glossaries:
-                gls_title = self.get_multilingual_text(gls.title)[0]['Text']
-                if gls_title is not None:
+                gls_title = self.get_multilingual_text(gls.title)
+                gls_title_text = gls_title[0]['Text']
+                if gls_title_text is not None:
                     glossaries.append({
-                        'Title': self.get_multilingual_text(gls.title),
+                        'Title': gls_title,
                         'Content': self.get_multilingual_text(gls.content)
                     })
                 else:

--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -136,10 +136,15 @@ class Renderer(Base):
         if isinstance(extract.glossaries, list) and len(extract.glossaries) > 0:
             glossaries = list()
             for gls in extract.glossaries:
-                glossaries.append({
-                    'Title': self.get_multilingual_text(gls.title),
-                    'Content': self.get_multilingual_text(gls.content)
-                })
+                gls_title = self.get_multilingual_text(gls.title)[0]['Text']
+                if gls_title is not None:
+                    glossaries.append({
+                        'Title': self.get_multilingual_text(gls.title),
+                        'Content': self.get_multilingual_text(gls.content)
+                    })
+                else:
+                    log.warning("glossary entry in requested language missing for title {}".format(gls.title))
+
             extract_dict['Glossary'] = glossaries
 
         log.debug("_render() done.")


### PR DESCRIPTION
check if glossary entry has content before adding it. This avoids a glossary entry with null value appearing in the extract.

That is the case currently for example when using the stand-alone version, as there is a test data entry {'fr': 'SGRF'}  with no corresponding entry for 'de', the extract currently contains:
`{"Title": [{"Language": "de", "Text": null}], "Content": [{"Language": "de", "Text": null}]}]}`

After the PR, such an entry will not be written, instead, a warning will be logged.

Note that as a side-effect, this will allow the extract data to be printable with mapfish-print 3.12.0. The newer version of mapfish-print is more strict with data content then the mapfish-print 3.10 version.