### PR TITLE
Fix map bbox+buffer calculation

### DIFF
--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -68,8 +68,8 @@ vars:
       # extract. Here you can define the path to the logic which prepares the output as payload for print
       # service and returns the result to the user.
       renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
-      # The buffer on the map around the parcel in percent
-      buffer: 10
+      # The minimum buffer in pixel between the real estate and the map's border.
+      buffer: 30
       # The map size in pixel at 72 DPI (width, height), This is the defined size of a map image
       # (requested in wms urls) inside the static extract. On a pdf report, tha map size will
       # be calculated with the pdf_dpi and the pdf_map_size_millimeters below.

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -68,7 +68,7 @@ vars:
       # extract. Here you can define the path to the logic which prepares the output as payload for print
       # service and returns the result to the user.
       renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
-      # The minimum buffer in pixel between the real estate and the map's border.
+      # The minimum buffer in pixel at 72 DPI between the real estate and the map's border.
       buffer: 30
       # The map size in pixel at 72 DPI (width, height), This is the defined size of a map image
       # (requested in wms urls) inside the static extract. On a pdf report, tha map size will

--- a/pyramid_oereb/lib/readers/extract.py
+++ b/pyramid_oereb/lib/readers/extract.py
@@ -106,9 +106,7 @@ class ExtractReader(object):
         log.debug("read() start")
         assert isinstance(municipality.logo, ImageRecord)
 
-        print_conf = Config.get_object_path('print', required=['buffer'])
-        map_size = ViewServiceRecord.get_map_size(params.format)
-        bbox = ViewServiceRecord.get_bbox(real_estate.limit, map_size, print_conf['buffer'])
+        bbox = ViewServiceRecord.get_bbox(real_estate.limit)
         bbox = box(bbox[0], bbox[1], bbox[2], bbox[3])
 
         datasource = list()

--- a/pyramid_oereb/lib/records/view_service.py
+++ b/pyramid_oereb/lib/records/view_service.py
@@ -109,38 +109,31 @@ class ViewServiceRecord(object):
         geom_ration = geom_width / geom_height
         map_ration = map_width / map_height
 
-        must_adapt_width = geom_ration < map_ration
+        # If the format of the map is naturally adapted to the format of the geometry
+        is_format_adapted = geom_ration < map_ration
 
-        if must_adapt_width:
-            # Height is correct, so calculate a buffer on the height of the geometry.
-            buffer = geom_height * (float(print_buffer) / float(map_height))
+        if is_format_adapted:
+            map_height_without_buffer = map_height - 2 * print_buffer
+            # Calculate the new height of the geom with the buffer.
+            geom_height_with_buffer = map_height / map_height_without_buffer * geom_height
+            # Calculate the new geom width with the map ratio and the new geom height.
+            geom_width_with_buffer = geom_height_with_buffer * map_ration
         else:
-            # Width is correct, so calculate a buffer on the width of the geometry.
-            buffer = geom_width * (float(print_buffer) / float(map_width))
+            map_width_without_buffer = map_width - 2 * print_buffer
+            # Calculate the new width of the geom with the buffer.
+            geom_width_with_buffer = map_width / map_width_without_buffer * geom_width
+            # Calculate the new geom height with the map ratio and the new geom width.
+            geom_height_with_buffer = geom_width_with_buffer * map_ration
 
-        # Create the print bounds with the geom and the buffer.
-        print_bounds = [
-            geom_bounds[0] - buffer,
-            geom_bounds[1] - buffer,
-            geom_bounds[2] + buffer,
-            geom_bounds[3] + buffer,
+        height_to_add = (geom_height_with_buffer - geom_height) / 2
+        width_to_add = (geom_width_with_buffer - geom_width) / 2
+
+        return [
+            geom_bounds[0] - width_to_add,
+            geom_bounds[1] - height_to_add,
+            geom_bounds[2] + width_to_add,
+            geom_bounds[3] + height_to_add,
         ]
-
-        print_width = float(print_bounds[2] - print_bounds[0])
-        print_height = float(print_bounds[3] - print_bounds[1])
-
-        if must_adapt_width:
-            # Will adapt the print bounds on the top and the bottom of the geometry.
-            to_add = (map_width / (map_height / print_height) - print_width) / 2
-            print_bounds[0] -= to_add
-            print_bounds[2] += to_add
-        else:
-            # Will adapt the print bounds on the right and the left of the geometry.
-            to_add = (map_height / (map_width / print_width) - print_height) / 2
-            print_bounds[1] -= to_add
-            print_bounds[3] += to_add
-
-        return print_bounds
 
     def get_full_wms_url(self, real_estate, format):
         """

--- a/pyramid_oereb/lib/records/view_service.py
+++ b/pyramid_oereb/lib/records/view_service.py
@@ -95,16 +95,18 @@ class ViewServiceRecord(object):
         ]
         width = float(print_bounds[2] - print_bounds[0])
         height = float(print_bounds[3] - print_bounds[1])
+        map_width = map_size[0]
+        map_height = map_size[1]
 
         obj_ration = width / height
         print_ration = float(map_size[0]) / float(map_size[1])
 
         if obj_ration < print_ration:
-            to_add = ((width / obj_ration * print_ration) - width) / 2
+            to_add = (map_width / (map_height / height) - width) / 2
             print_bounds[0] -= to_add
             print_bounds[2] += to_add
         else:
-            to_add = (height - (height / obj_ration * print_ration)) / 2
+            to_add = (map_height / (map_width / width) - height) / 2
             print_bounds[1] -= to_add
             print_bounds[3] += to_add
 

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -67,7 +67,7 @@ pyramid_oereb:
     # extract. Here you can define the path to the logic which prepares the output as payload for print
     # service and returns the result to the user.
     renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
-    # The minimum buffer in pixel between the real estate and the map's border.
+    # The minimum buffer in pixel at 72 DPI between the real estate and the map's border.
     buffer: 30
     # The map size in pixel at 72 DPI (width, height), This is the defined size of a map image
     # (requested in wms urls) inside the static extract. On a pdf report, tha map size will

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -67,8 +67,8 @@ pyramid_oereb:
     # extract. Here you can define the path to the logic which prepares the output as payload for print
     # service and returns the result to the user.
     renderer: pyramid_oereb.contrib.print_proxy.mapfish_print.Renderer
-    # The buffer on the map around the parcel in percent
-    buffer: 10
+    # The minimum buffer in pixel between the real estate and the map's border.
+    buffer: 30
     # The map size in pixel at 72 DPI (width, height), This is the defined size of a map image
     # (requested in wms urls) inside the static extract. On a pdf report, tha map size will
     # be calculated with the pdf_dpi and the pdf_map_size_millimeters below.


### PR DESCRIPTION
Wait on the next release of MapFishPrint.

Will fix https://github.com/camptocamp/pyramid_oereb/issues/355

Note: I wonder if we can remove this config: https://github.com/camptocamp/pyramid_oereb/blob/master/pyramid_oereb/standard/pyramid_oereb.yml.mako#L79 I mean, we can calculate this information.