### PR TITLE
Be able to (easily) override get document_records methode in plr

### DIFF
--- a/pyramid_oereb/contrib/sources/plr_oereblex.py
+++ b/pyramid_oereb/contrib/sources/plr_oereblex.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from pyramid_oereb import Config
+from pyramid_oereb.contrib.sources.document import OEREBlexSource
+from pyramid_oereb.standard.sources.plr import DatabaseSource
+
+log = logging.getLogger(__name__)
+
+
+class DatabaseOEREBlexSource(DatabaseSource):
+    """
+    A source to get oereblex documents attached to public law restrictions in replacement
+    of standards documents. Be sure to use a model with an OEREBlex "lexlink" integer
+    column for plrs that use this source.
+    """
+    def __init__(self, **kwargs):
+        """
+        Keyword Arguments:
+            name (str): The name. You are free to choose one.
+            code (str): The official code. Regarding to the federal specifications.
+            geometry_type (str): The geometry type. Possible are: POINT, POLYGON, LINESTRING,
+                GEOMETRYCOLLECTION
+            thresholds (dict): The configuration of limits, units and precision which is used for processing.
+            text (dict of str): The speaking title. It must be a dictionary containing language (as
+                configured) as key and text as value.
+            language (str): The language this public law restriction is originally shipped whith.
+            federal (bool): Switch if it is a federal topic. This will be taken into account in processing
+                steps.
+            source (dict): The configuration dictionary of the public law restriction
+            hooks (dict of str): The hook methods: get_symbol, get_symbol_ref. They have to be provided as
+                dotted string for further use with dotted name resolver of pyramid package.
+            law_status (dict of str): The multiple match configuration to provide more flexible use of the
+                federal specified classifiers 'inForce' and 'runningModifications'.
+        """
+        super(DatabaseOEREBlexSource, self).__init__()
+        self._oereblex_source = OEREBlexSource(**Config.get_oereblex_config())
+
+    def get_document_records(self, public_law_restriction_from_db):
+        """
+        Override the parent's get_document_records method to obtain the oereblex document instead.
+        """
+        return self.document_records_from_oereblex(public_law_restriction_from_db.geolink)
+
+    def document_records_from_oereblex(self, lexlink):
+        """
+        Create document records parsed from the OEREBlex response with the specified geoLink ID and appends
+        them to the current public law restriction.
+
+        Args:
+            lexlink (int): The ID of the geoLink to request the documents for.
+
+        Returns:
+            list of pyramid_oereb.lib.records.documents.DocumentRecord:
+                The documents created from the parsed OEREBlex response.
+        """
+        log.warn("document_records_from_oereblex() start")
+        self._oereblex_source.read(lexlink)
+        log.warn("document_records_from_oereblex() returning records")
+        return self._oereblex_source.records

--- a/pyramid_oereb/standard/sources/plr.py
+++ b/pyramid_oereb/standard/sources/plr.py
@@ -315,14 +315,8 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
             public_law_restriction_from_db.view_service,
             legend_entry_records
         )
-        documents_from_db = []
-        article_numbers = []
-        for i, legal_provision in enumerate(public_law_restriction_from_db.legal_provisions):
-            documents_from_db.append(legal_provision.document)
-            article_nrs = legal_provision.article_numbers.split('|') if legal_provision.article_numbers \
-                else None
-            article_numbers.append(article_nrs)
-        document_records = self.from_db_to_document_records(documents_from_db, article_numbers)
+
+        document_records = self.get_document_records(public_law_restriction_from_db)
         geometry_records = self.from_db_to_geometry_records(public_law_restriction_from_db.geometries)
 
         basis_plr_records = []
@@ -365,6 +359,16 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
         )
 
         return plr_record
+
+    def get_document_records(self, public_law_restriction_from_db):
+        documents_from_db = []
+        article_numbers = []
+        for i, legal_provision in enumerate(public_law_restriction_from_db.legal_provisions):
+            documents_from_db.append(legal_provision.document)
+            article_nrs = legal_provision.article_numbers.split('|') if legal_provision.article_numbers \
+                else None
+            article_numbers.append(article_nrs)
+        return self.from_db_to_document_records(documents_from_db, article_numbers)
 
     @staticmethod
     def extract_geometry_collection_db(db_path, real_estate_geometry):


### PR DESCRIPTION
(For: GEO-941 - reduce code duplication)

I just moved out into its own function the logic to get document_records of a plr.

My final aim is to simplify the way to have oereblex documents in the plr. Before, for Schwyz, we replace almost the whole standard/sources/plr.py file only to have the oereblex documents (and that was hard to maintain). With this logic we can do it easily, just by inheritance and by overridden the "get_document_records" method. So,  like that in a project that want to use oereblex documents (and not more):

````
# -*- coding: utf-8 -*-                                                          
import base64                                                                    
import logging                                                                   
                                                                                 
from pyramid_oereb import Config                                                 
from pyramid_oereb.contrib.sources.document import OEREBlexSource                
from pyramid_oereb.lib.sources.plr import PlrBaseSource                          
                                                                                 
from pyramid_oereb.standard.sources.plr import DatabaseSource                    
                                                                                 
log = logging.getLogger(__name__)                                                                                                                         
                                                                                 
class DatabaseOEREBlexSource(DatabaseSource):                                    
    def __init__(self, **kwargs):                                                
        """                                                                      
        Keyword Arguments:                                                       
            name (str): The name. You are free to choose one.                    
            code (str): The official code. Regarding to the federal specifications.
            geometry_type (str): The geometry type. Possible are: POINT, POLYGON, LINESTRING,
                GEOMETRYCOLLECTION                                               
            thresholds (dict): The configuration of limits, units and precision which is used for processing.
            text (dict of str): The speaking title. It must be a dictionary containing language (as
                configured) as key and text as value.                            
            language (str): The language this public law restriction is originally shipped whith.
            federal (bool): Switch if it is a federal topic. This will be taken into account in processing
                steps.                                                           
            source (dict): The configuration dictionary of the public law restriction
            hooks (dict of str): The hook methods: get_symbol, get_symbol_ref. They have to be provided as
                dotted string for further use with dotted name resolver of pyramid package.
            law_status (dict of str): The multiple match configuration to provide more flexible use of the
                federal specified classifiers 'inForce' and 'runningModifications'.
        """                                                                      
        self._oereblex_source = OEREBlexSource(**Config.get_oereblex_config())   
        DatabaseSource.__init__(self, **kwargs)                                                                                                      
                                                                                 
    def get_document_records(self, public_law_restriction_from_db):
        """
        Override the parent get_document_records method to obtais the oereblex document instead. 
        """              
        return self.document_records_from_oereblex(public_law_restriction_from_db.geolink)                                                            
                                                                                 
    def document_records_from_oereblex(self, lexlink):                           
        """                                                                      
        Create document records parsed from the OEREBlex response with the specified geoLink ID and appends
        them to the current public law restriction.                              
                                                                                 
        Args:                                                                    
            lexlink (int): The ID of the geoLink to request the documents for.   
                                                                                 
        Returns:                                                                 
            list of pyramid_oereb.lib.records.documents.DocumentRecord:          
                The documents created from the parsed OEREBlex response.         
        """                                                                      
        log.warn("document_records_from_oereblex() start")                       
        self._oereblex_source.read(lexlink)                                      
        log.warn("document_records_from_oereblex() returning records")           
        return self._oereblex_source.records  
````

I've not passed a lot of time to do that, perhaps I miss something. What do you think @vvmruder ?

---

Then, a next point **may** to have the geolink column directly into the standard model. Do you think its 
feasible ?