### PR TITLE
Fix glossary layout in PDF

### DIFF
--- a/print/print-apps/oereb/glossar.jrxml
+++ b/print/print-apps/oereb/glossar.jrxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
+<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" uuid="9a3e59f5-6675-48cf-ad74-9c42b5a5b290">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
@@ -20,10 +20,10 @@
 	<parameter name="RealEstate_Municipality" class="java.lang.String"/>
 	<parameter name="GlossaryDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<detail>
-		<band height="134">
+		<band height="146">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 			<textField>
-				<reportElement x="0" y="68" width="493" height="30" uuid="98a07dd4-c09b-4074-901d-66449b033be9">
+				<reportElement x="0" y="83" width="493" height="30" uuid="98a07dd4-c09b-4074-901d-66449b033be9">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
@@ -99,7 +99,7 @@
 				<imageExpression><![CDATA[$P{LogoPLRCadastreRef}]]></imageExpression>
 			</image>
 			<subreport>
-				<reportElement x="0" y="113" width="493" height="21" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="009c2034-ceb4-490f-9686-98faab99a1d5">
+				<reportElement x="0" y="125" width="493" height="21" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="009c2034-ceb4-490f-9686-98faab99a1d5">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<dataSourceExpression><![CDATA[$P{GlossaryDataSource}]]></dataSourceExpression>

--- a/print/print-apps/oereb/table.jrxml
+++ b/print/print-apps/oereb/table.jrxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.4.0.final using JasperReports Library version 6.4.1  -->
+<!-- Created with Jaspersoft Studio version 6.5.1.final using JasperReports Library version 6.5.1  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Contents" pageWidth="493" pageHeight="842" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Key" uuid="e034c6ef-7449-4a6a-9b5e-4ce04cc083b2">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
@@ -22,13 +22,15 @@
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
-				<box>
+				<box topPadding="3" bottomPadding="3">
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
-				<textElement markup="html"/>
+				<textElement markup="html">
+					<font size="9"/>
+				</textElement>
 				<textFieldExpression><![CDATA[($F{Title}.equals("") || $F{Title}.equals("null") || $F{Title} == null) ? "-" : "<b>"+$F{Title}+":</b> " + $F{Content}]]></textFieldExpression>
 			</textField>
 		</band>


### PR DESCRIPTION
Some glossary texts are cut off in the PDF extract. Use an integer font size to avoid rendering issues.