### PR TITLE
Fix versions response

### DIFF
--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -62,7 +62,7 @@ class PlrWebservice(object):
             u'GetVersionsResponse': {
                 u'supportedVersion': [
                     {
-                        u'version': u'1.0.0',
+                        u'version': u'0.4',
                         u'serviceEndpointBase': endpoint
                     }
                 ]


### PR DESCRIPTION
Return the correct specification version (0.4) which is supported.

Fixes #494 