### PR TITLE
Add format for versions and capabilities

### DIFF
--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -97,6 +97,31 @@ def includeme(config):  # pragma: no cover
     )
 
     # Get egrid
+    config.add_route('{0}/getegrid_coord/'.format(route_prefix), '/getegrid/{format}/')
+    config.add_route('{0}/getegrid_ident/'.format(route_prefix), '/getegrid/{format}/{identdn}/{number}')
+    config.add_route('{0}/getegrid_address/'.format(route_prefix),
+                     '/getegrid/{format}/{postalcode}/{localisation}/{number}')
+    config.add_view(
+        PlrWebservice,
+        attr='get_egrid_coord',
+        route_name='{0}/getegrid_coord/'.format(route_prefix),
+        request_method='GET'
+    )
+    config.add_view(
+        PlrWebservice,
+        attr='get_egrid_ident',
+        route_name='{0}/getegrid_ident/'.format(route_prefix),
+        request_method='GET'
+    )
+    config.add_view(
+        PlrWebservice,
+        attr='get_egrid_address',
+        route_name='{0}/getegrid_address/'.format(route_prefix),
+        request_method='GET'
+    )
+
+
+    # TODO remove me later. Get egrid - backward compatibility routes
     config.add_route('{0}/getegrid_coord.json'.format(route_prefix), '/getegrid.json')
     config.add_route('{0}/getegrid_ident.json'.format(route_prefix), '/getegrid/{identdn}/{number}.json')
     config.add_route('{0}/getegrid_address.json'.format(route_prefix),
@@ -141,26 +166,12 @@ def includeme(config):  # pragma: no cover
         route_name='{0}/getegrid_address'.format(route_prefix),
         request_method='GET'
     )
-    config.add_route('{0}/getegrid_coord/'.format(route_prefix), '/getegrid/')
-    config.add_route('{0}/getegrid_ident/'.format(route_prefix), '/getegrid/{identdn}/{number}/')
-    config.add_route('{0}/getegrid_address/'.format(route_prefix),
-                     '/getegrid/{postalcode}/{localisation}/{number}/')
+
+    config.add_route('{0}/getegrid_coord_old/'.format(route_prefix), '/getegrid/')
     config.add_view(
         PlrWebservice,
         attr='get_egrid_coord',
-        route_name='{0}/getegrid_coord/'.format(route_prefix),
-        request_method='GET'
-    )
-    config.add_view(
-        PlrWebservice,
-        attr='get_egrid_ident',
-        route_name='{0}/getegrid_ident/'.format(route_prefix),
-        request_method='GET'
-    )
-    config.add_view(
-        PlrWebservice,
-        attr='get_egrid_address',
-        route_name='{0}/getegrid_address/'.format(route_prefix),
+        route_name='{0}/getegrid_coord_old/'.format(route_prefix),
         request_method='GET'
     )
 

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -41,7 +41,7 @@ def includeme(config):  # pragma: no cover
         request_method='GET'
     )
 
-    # TODO remove me later. Get version - backward compatibility routes
+    # Get version - Can be removed if backward compatibility no longer required.
     config.add_route('{0}/versions.json'.format(route_prefix), '/versions.json')
     config.add_view(
         PlrWebservice,
@@ -73,7 +73,7 @@ def includeme(config):  # pragma: no cover
         request_method='GET'
     )
 
-    # TODO remove me later. Get capabilities - backward compatibility routes
+    # Get capabilities - Can be removed if backward compatibility no longer required.
     config.add_route('{0}/capabilities.json'.format(route_prefix), '/capabilities.json')
     config.add_view(
         PlrWebservice,
@@ -120,8 +120,7 @@ def includeme(config):  # pragma: no cover
         request_method='GET'
     )
 
-
-    # TODO remove me later. Get egrid - backward compatibility routes
+    # Get egrid - Can be removed if backward compatibility no longer required.
     config.add_route('{0}/getegrid_coord.json'.format(route_prefix), '/getegrid.json')
     config.add_route('{0}/getegrid_ident.json'.format(route_prefix), '/getegrid/{identdn}/{number}.json')
     config.add_route('{0}/getegrid_address.json'.format(route_prefix),
@@ -146,8 +145,10 @@ def includeme(config):  # pragma: no cover
     )
     config.add_route('{0}/getegrid_coord'.format(route_prefix), '/getegrid')
     config.add_route('{0}/getegrid_ident'.format(route_prefix), '/getegrid/{identdn}/{number}')
-    config.add_route('{0}/getegrid_address'.format(route_prefix),
-                     '/getegrid/{postalcode}/{localisation}/{number}')
+    # This legacy route (old specification) can't work anymore because of the one with {format} so it's
+    # commented and the view removed.
+    # config.add_route('{0}/getegrid_address'.format(route_prefix),
+    #                 '/getegrid/{postalcode}/{localisation}/{number}')
     config.add_view(
         PlrWebservice,
         attr='get_egrid_coord',
@@ -158,12 +159,6 @@ def includeme(config):  # pragma: no cover
         PlrWebservice,
         attr='get_egrid_ident',
         route_name='{0}/getegrid_ident'.format(route_prefix),
-        request_method='GET'
-    )
-    config.add_view(
-        PlrWebservice,
-        attr='get_egrid_address',
-        route_name='{0}/getegrid_address'.format(route_prefix),
         request_method='GET'
     )
 

--- a/pyramid_oereb/routes.py
+++ b/pyramid_oereb/routes.py
@@ -33,6 +33,15 @@ def includeme(config):  # pragma: no cover
                     request_method='GET')
 
     # Get versions
+    config.add_route('{0}/versions/'.format(route_prefix), '/versions/{format}')
+    config.add_view(
+        PlrWebservice,
+        attr='get_versions',
+        route_name='{0}/versions/'.format(route_prefix),
+        request_method='GET'
+    )
+
+    # TODO remove me later. Get version - backward compatibility routes
     config.add_route('{0}/versions.json'.format(route_prefix), '/versions.json')
     config.add_view(
         PlrWebservice,
@@ -47,15 +56,24 @@ def includeme(config):  # pragma: no cover
         route_name='{0}/versions'.format(route_prefix),
         request_method='GET'
     )
-    config.add_route('{0}/versions/'.format(route_prefix), '/versions/')
+    config.add_route('{0}/versions_old/'.format(route_prefix), '/versions/')
     config.add_view(
         PlrWebservice,
         attr='get_versions',
-        route_name='{0}/versions/'.format(route_prefix),
+        route_name='{0}/versions_old/'.format(route_prefix),
         request_method='GET'
     )
 
     # Get capabilities
+    config.add_route('{0}/capabilities/'.format(route_prefix), '/capabilities/{format}')
+    config.add_view(
+        PlrWebservice,
+        attr='get_capabilities',
+        route_name='{0}/capabilities/'.format(route_prefix),
+        request_method='GET'
+    )
+
+    # TODO remove me later. Get capabilities - backward compatibility routes
     config.add_route('{0}/capabilities.json'.format(route_prefix), '/capabilities.json')
     config.add_view(
         PlrWebservice,
@@ -70,11 +88,11 @@ def includeme(config):  # pragma: no cover
         route_name='{0}/capabilities'.format(route_prefix),
         request_method='GET'
     )
-    config.add_route('{0}/capabilities/'.format(route_prefix), '/capabilities/')
+    config.add_route('{0}/capabilities_old'.format(route_prefix), '/capabilities/')
     config.add_view(
         PlrWebservice,
         attr='get_capabilities',
-        route_name='{0}/capabilities/'.format(route_prefix),
+        route_name='{0}/capabilities_old'.format(route_prefix),
         request_method='GET'
     )
 

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -371,7 +371,15 @@ class PlrWebservice(object):
                 'identDN': getattr(r, 'identdn')
             })
         egrid = {'GetEGRIDResponse': real_estates}
-        renderer_name = 'json' if self._is_json() else 'pyramid_oereb_getegrid_xml'
+
+        # TODO remove me later. Try - catch for backward compatibility
+        try :
+            format = self.__validate_format_param__(['xml', 'json'])
+            renderer_name = 'json' if format == 'json' else 'pyramid_oereb_getegrid_xml'
+        except HTTPBadRequest:
+            renderer_name = 'json' if self._is_json() else 'pyramid_oereb_getegrid_xml'
+            log.warn('Deprecated way to specify the format. Use "/getegrid/{format}/..." instead')
+
         response = render_to_response(renderer_name, egrid, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -33,7 +33,7 @@ class PlrWebservice(object):
         self._real_estate_reader = request.pyramid_oereb_processor.real_estate_reader
         self._municipality_reader = request.pyramid_oereb_processor.municipality_reader
 
-    # TODO remove me later. For backward capability.
+    # For backward compatibility with old specification.
     def _is_json(self):
         """
         Returns True if the requests format is JSON.
@@ -68,10 +68,10 @@ class PlrWebservice(object):
                 ]
             }
         }
-        # TODO remove me later. Try - catch for backward compatibility
-        try :
-            format = self.__validate_format_param__(['xml', 'json'])
-            renderer_name = 'json' if format == 'json' else 'pyramid_oereb_versions_xml'
+        # Try - catch for backward compatibility with old specification.
+        try:
+            output_format = self.__validate_format_param__(['xml', 'json'])
+            renderer_name = 'json' if output_format == 'json' else 'pyramid_oereb_versions_xml'
         except HTTPBadRequest:
             renderer_name = 'json' if self._is_json() else 'pyramid_oereb_versions_xml'
             log.warn('Deprecated way to specify the format. Use "/versions/{format}" instead')
@@ -110,10 +110,10 @@ class PlrWebservice(object):
             }
         }
 
-        # TODO remove me later. Try - catch for backward compatibility
-        try :
-            format = self.__validate_format_param__(['xml', 'json'])
-            renderer_name = 'json' if format == 'json' else 'pyramid_oereb_capabilities_xml'
+        # Try - catch for backward compatibility with old specification.
+        try:
+            output_format = self.__validate_format_param__(['xml', 'json'])
+            renderer_name = 'json' if output_format == 'json' else 'pyramid_oereb_capabilities_xml'
         except HTTPBadRequest:
             renderer_name = 'json' if self._is_json() else 'pyramid_oereb_capabilities_xml'
             log.warn('Deprecated way to specify the format. Use "/capabilities/{format}" instead')
@@ -311,7 +311,6 @@ class PlrWebservice(object):
 
         return params
 
-
     def __validate_format_param__(self, accepted_formats):
         """
         Get format in the url and validate that it's one accepted.
@@ -322,12 +321,10 @@ class PlrWebservice(object):
         Returns:
             str: The validated format parameter.
         """
-        extract_format = self._request.matchdict.get('format', '').lower()
-        if extract_format not in accepted_formats:
-            raise HTTPBadRequest('Invalid format: {0}'.format(extract_format))
-        return extract_format
-
-
+        output_format = self._request.matchdict.get('format', '').lower()
+        if output_format not in accepted_formats:
+            raise HTTPBadRequest('Invalid format: {0}'.format(output_format))
+        return output_format
 
     def __coord_transform__(self, coord, source_crs):
         """
@@ -372,10 +369,10 @@ class PlrWebservice(object):
             })
         egrid = {'GetEGRIDResponse': real_estates}
 
-        # TODO remove me later. Try - catch for backward compatibility
-        try :
-            format = self.__validate_format_param__(['xml', 'json'])
-            renderer_name = 'json' if format == 'json' else 'pyramid_oereb_getegrid_xml'
+        # Try - catch for backward compatibility with old specification.
+        try:
+            output_format = self.__validate_format_param__(['xml', 'json'])
+            renderer_name = 'json' if output_format == 'json' else 'pyramid_oereb_getegrid_xml'
         except HTTPBadRequest:
             renderer_name = 'json' if self._is_json() else 'pyramid_oereb_getegrid_xml'
             log.warn('Deprecated way to specify the format. Use "/getegrid/{format}/..." instead')

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -33,7 +33,7 @@ class PlrWebservice(object):
         self._real_estate_reader = request.pyramid_oereb_processor.real_estate_reader
         self._municipality_reader = request.pyramid_oereb_processor.municipality_reader
 
-    # TODO: Remove this method when format parameter is available in URL (new specification).
+    # TODO remove me later. For backward capability.
     def _is_json(self):
         """
         Returns True if the requests format is JSON.
@@ -68,7 +68,14 @@ class PlrWebservice(object):
                 ]
             }
         }
-        renderer_name = 'json' if self._is_json() else 'pyramid_oereb_versions_xml'
+        # TODO remove me later. Try - catch for backward compatibility
+        try :
+            format = self.__validate_format_param__(['xml', 'json'])
+            renderer_name = 'json' if format == 'json' else 'pyramid_oereb_versions_xml'
+        except HTTPBadRequest:
+            renderer_name = 'json' if self._is_json() else 'pyramid_oereb_versions_xml'
+            log.warn('Deprecated way to specify the format. Use "/versions/{format}" instead')
+
         response = render_to_response(renderer_name, versions, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
@@ -102,7 +109,15 @@ class PlrWebservice(object):
                 u'crs': Config.get_crs()
             }
         }
-        renderer_name = 'json' if self._is_json() else 'pyramid_oereb_capabilities_xml'
+
+        # TODO remove me later. Try - catch for backward compatibility
+        try :
+            format = self.__validate_format_param__(['xml', 'json'])
+            renderer_name = 'json' if format == 'json' else 'pyramid_oereb_capabilities_xml'
+        except HTTPBadRequest:
+            renderer_name = 'json' if self._is_json() else 'pyramid_oereb_capabilities_xml'
+            log.warn('Deprecated way to specify the format. Use "/capabilities/{format}" instead')
+
         response = render_to_response(renderer_name, capabilities, request=self._request)
         if self._is_json():
             response.content_type = 'application/json; charset=UTF-8'
@@ -239,10 +254,8 @@ class PlrWebservice(object):
         if extract_flavour not in ['reduced', 'full', 'signed', 'embeddable']:
             raise HTTPBadRequest('Invalid flavour: {0}'.format(extract_flavour))
 
-        # Check format
-        extract_format = self._request.matchdict.get('format').lower()
-        if extract_format not in ['pdf', 'xml', 'json']:
-            raise HTTPBadRequest('Invalid format: {0}'.format(extract_format))
+        # Get and check format
+        extract_format = self.__validate_format_param__(['pdf', 'xml', 'json'])
 
         # With geometry?
         with_geometry = False
@@ -297,6 +310,24 @@ class PlrWebservice(object):
             params.set_topics(topics.split(','))
 
         return params
+
+
+    def __validate_format_param__(self, accepted_formats):
+        """
+        Get format in the url and validate that it's one accepted.
+
+        Args:
+            accepted_formats (list): A list of accepted format (str).
+
+        Returns:
+            str: The validated format parameter.
+        """
+        extract_format = self._request.matchdict.get('format', '').lower()
+        if extract_format not in accepted_formats:
+            raise HTTPBadRequest('Invalid format: {0}'.format(extract_format))
+        return extract_format
+
+
 
     def __coord_transform__(self, coord, source_crs):
         """


### PR DESCRIPTION
GSOREB-240

Add routes:
 - `${baseurl}/getegrid/${FORMAT}/?XY=${XY}`
 - `${baseurl}/getegrid/${FORMAT}/${IDENTDN}/${NUMBER}`
 - `${baseurl}/getegrid/${FORMAT}/${POSTALCODE}/${LOCALISATION}/${NUMBER}`
 - `${baseurl}/getegrid/${FORMAT}/?GNSS=${GNSS}`
 - `${baseurl}/capabilities/${FORMAT}`
 - `${baseurl}/versions/${FORMAT}`

Old routes still works, but with a warning.
**EXCEPT FOR**: https://github.com/camptocamp/pyramid_oereb/blob/ccb1d7603a31ae83b35917590d3a8ad1906e851d/pyramid_oereb/routes.py#L149

Pyramid can't know if it's:
 - `${baseurl}/getegrid/${FORMAT}/${IDENTDN}/${NUMBER}`
or
 - `${baseurl}/getegrid/${POSTALCODE}/${IDENTDN}/${NUMBER}`

So I've commented this route