### PR TITLE
Add border around the scale of scalebar

### DIFF
--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -216,6 +216,7 @@ templates:
                   fontSize: 6
                   align: "center"
                   padding: 2
+                  lineWidth: 1
                   backgroundColor: "rgba(255, 255, 255, 255)"
             features: !features {}
             map: !map


### PR DESCRIPTION
Fixes #536 
This just adds a border around the scale bar to better indicate where the start-/end-point of the scale bar is located
![image](https://user-images.githubusercontent.com/1460598/43068581-1d83c628-8e6b-11e8-8c98-52b9aa50f217.png)
