### PR TITLE
Replace old certificationText with certification attri. in print

### DIFF
--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -41,6 +41,7 @@ templates:
             MunicipalityLogo: *optStr
             MunicipalityLogoRef: *optStr
             ExtractIdentifier: !string {}
+            Certification: !string {} #/definitions/MultilingualMText
             Footer: !string {}
             QRCode: *optStr
             QRCodeRef: *optStr
@@ -249,7 +250,6 @@ templates:
                                 strokeOpacity: 0.60
                                 strokeWidth: 5
             furtherInformationText: !string {}
-            certificationText: !string {}
 
         processors:
         - !reportBuilder # compile all reports in current directory

--- a/print/print-apps/oereb/mainpage.jrxml
+++ b/print/print-apps/oereb/mainpage.jrxml
@@ -36,7 +36,7 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>
-    <parameter name="certificationText" class="java.lang.String"/>
+    <parameter name="Certification" class="java.lang.String"/>
 	<title>
 		<band height="735">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
@@ -159,7 +159,7 @@
 				<textElement>
 					<font fontName="Cadastra" size="7"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{certificationText}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{Certification}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="0" y="506" width="493" height="17" uuid="b1be1539-699e-4517-9297-bca1bb7db679">

--- a/print/print-apps/oereb/pdfextract.jrxml
+++ b/print/print-apps/oereb/pdfextract.jrxml
@@ -54,7 +54,7 @@
 	<parameter name="RealEstate_RestrictionOnLandownershipDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<parameter name="GlossaryDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
     <parameter name="furtherInformationText" class="java.lang.String"/>
-    <parameter name="certificationText" class="java.lang.String"/>
+    <parameter name="Certification" class="java.lang.String"/>
 	<variable name="TOC_Appendices" class="java.util.Map">
 		<variableExpression><![CDATA[new java.util.HashMap()]]></variableExpression>
 	</variable>
@@ -158,8 +158,8 @@
 					<subreportParameter name="REPORT_RESOURCE_BUNDLE">
 						<subreportParameterExpression><![CDATA[$P{REPORT_RESOURCE_BUNDLE}]]></subreportParameterExpression>
 					</subreportParameter>
-					<subreportParameter name="certificationText">
-						<subreportParameterExpression><![CDATA[$P{certificationText}]]></subreportParameterExpression>
+					<subreportParameter name="Certification">
+						<subreportParameterExpression><![CDATA[$P{Certification}]]></subreportParameterExpression>
 					</subreportParameter>
 					<subreportExpression><![CDATA["mainpage.jasper"]]></subreportExpression>
 				</p:subreportPart>

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -78,12 +78,6 @@ class Renderer(JsonRenderer):
             self._language, '-'
         )
 
-        extract_as_dict['certificationText'] = print_config.get(
-            'certificationText', {}
-        ).get(
-            self._language, '-'
-        )
-
         extract_as_dict['Display_RealEstate_SubunitOfLandRegister'] = print_config.get(
             'display_real_estate_subunit_of_land_register', True
         )
@@ -206,6 +200,8 @@ class Renderer(JsonRenderer):
 
         self._multilingual_m_text(extract_dict, 'GeneralInformation')
         self._multilingual_m_text(extract_dict, 'BaseData')
+        self._multilingual_m_text(extract_dict, 'Certification')
+
         for item in extract_dict.get('Glossary', []):
             self._multilingual_text(item, 'Title')
             self._multilingual_text(item, 'Content')

--- a/tests/contrib/print_proxy/resources/expected_getspec_extract.json
+++ b/tests/contrib/print_proxy/resources/expected_getspec_extract.json
@@ -1,5 +1,5 @@
 {
-  "Certification": [{"Language": "de", "Text": "Referenz zur kantonsspezifischen Gesetzesgrundlage bez\u00fcglich Beglaubigungen."}],
+  "Certification": "Referenz zur kantonsspezifischen Gesetzesgrundlage bez\u00fcglich Beglaubigungen.",
   "CertificationAtWeb": [{"Language": "de", "Text": "https://oereb.bl.ch/certification/de"}],
   "GeneralInformation": "Der Inhalt des \u00d6REB-Katasters wird als bekannt vorausgesetzt. Der Kanton Basel-Landschaft ist f\u00fcr die Genauigkeit und Verl\u00e4sslichkeit der gesetzgebenden Dokumente in elektronischer Form nicht haftbar. Der Auszug hat rein informativen Charakter und begr\u00fcndet insbesondere keine Rechte und Pflichten. Rechtsverbindlich sind diejenigen Dokumente, welche rechtskr\u00e4ftig verabschiedet oder ver\u00f6ffentlicht worden sind. Mit der Beglaubigung des Auszugs wird die \u00dcbereinstimmung des Auszugs mit dem \u00d6REB-Kataster zum Zeitpunkt der Auszugserstellung best\u00e4tigt.",
   "RealEstate_PlanForLandRegisterMainPage": {


### PR DESCRIPTION
GSOREB-249
Last point in https://jira.camptocamp.com/projects/GSOREB/issues/GSOREB-249
Consider the following:
- I did not add the `CertificationAtWeb` as it is not used for the moment --> see issue.
- https://github.com/camptocamp/pyramid_oereb/blob/master/doc/source/changes.rst contains some reference to the old attribute `certificationText` we should probability (re-)move this?