### PR TITLE
Major reconstruction of behaviour around ViewServiceRecord

### DIFF
--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -183,18 +183,16 @@ vars:
     # bound to the source. The model must implement the same field names and information then the default model
     # does.
     real_estate:
-      view_service:
-        # WMS URL to query the plan for land register
+      plan_for_land_register:
+        # WMS URL to query the plan for land register used for all themes pages
         reference_wms: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&STYLES=default&SRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
-        layer_index: 1
-        layer_opacity: 0.25
-        # Legend is optional
-        # legend_at_web:
-      # Overrides for main page of export.
-      # If a value cannot be found here, values from real_estate (parent of this attribute) will be used instead.
-      main_page:
-        view_service:
-          layer_opacity: 0.5
+        layer_index: 0
+        layer_opacity: 1.0
+      plan_for_land_register_main_page:
+        # WMS URL to query the plan for land register specially for static extracts overview page
+        reference_wms: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&STYLES=default&SRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
+        layer_index: 0
+        layer_opacity: 1.0
       visualisation:
         method: pyramid_oereb.standard.hook_methods.produce_sld_content
         # Note: This parameters must fit to the attributes provided by the RealEstateRecord!!!!
@@ -354,6 +352,9 @@ vars:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -387,6 +388,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -420,6 +424,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -453,6 +460,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -486,6 +496,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -519,6 +532,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -552,6 +568,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -585,6 +604,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -618,6 +640,9 @@ vars:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -651,6 +676,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -684,6 +712,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -717,6 +748,9 @@ vars:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -750,6 +784,9 @@ vars:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -783,6 +820,9 @@ vars:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -816,6 +856,9 @@ vars:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -849,6 +892,9 @@ vars:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -882,6 +928,9 @@ vars:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -185,7 +185,6 @@ class Renderer(JsonRenderer):
             'customParams': {'TRANSPARENT': 'true'},
         }
         extract_dict['baseLayers'] = {'layers': [main_page_basemap]}
-        extract_dict['legend'] = extract_dict['RealEstate_PlanForLandRegister'].get('LegendAtWeb', '')
         url, params = parse_url(extract_dict['RealEstate_PlanForLandRegister']['ReferenceWMS'])
         basemap = {
             'type': 'wms',

--- a/pyramid_oereb/lib/config.py
+++ b/pyramid_oereb/lib/config.py
@@ -4,7 +4,6 @@ import os
 import logging
 import datetime
 import yaml
-import copy
 import collections
 from pyramid.config import ConfigurationError
 from pyramid_oereb.lib.adapter import FileAdapter
@@ -176,18 +175,14 @@ class Config(object):
     @staticmethod
     def get_crs():
         """
-        Returns a list of available crs.
+        Returns a unicode string of configured crs.
 
         Returns:
-            list: The available crs.
+            unicode: The available crs.
         """
         assert Config._config is not None
-
-        crs = []
         srid = Config._config.get('srid')
-        if srid:
-            crs.append(u'epsg:{}'.format(srid))
-        return crs
+        return u'epsg:{}'.format(srid)
 
     @staticmethod
     def get_language():
@@ -250,15 +245,14 @@ class Config(object):
         return Config._config.get('real_estate')
 
     @staticmethod
-    def get_real_estate_main_page_config():
+    def get_plan_for_land_register_main_page_config():
         assert Config._config is not None
-        base = Config._config.get('real_estate', {})
-        base = copy.deepcopy(base)
-        if 'main_page' in base:
-            overwrite = base.get('main_page')
-            del base['main_page']
-            base = merge_dicts(base, overwrite)
-        return base
+        return Config._config.get('real_estate', {}).get('plan_for_land_register_main_page')
+
+    @staticmethod
+    def get_plan_for_land_register_config():
+        assert Config._config is not None
+        return Config._config.get('real_estate', {}).get('plan_for_land_register')
 
     @staticmethod
     def get_address_config():
@@ -552,5 +546,13 @@ class Config(object):
                     if view_service and isinstance(view_service, dict):
                         layer_index = view_service.get('layer_index')
                         layer_opacity = view_service.get('layer_opacity')
+                        if layer_opacity is None:
+                            raise ConfigurationError(
+                                'For {} the "layer_opacity" was not found!'.format(theme_code)
+                            )
+                        if layer_index is None:
+                            raise ConfigurationError(
+                                'For {} the "layer_index" was not found!'.format(theme_code)
+                            )
                         return layer_index, layer_opacity
         return None, None

--- a/pyramid_oereb/lib/processor.py
+++ b/pyramid_oereb/lib/processor.py
@@ -154,8 +154,10 @@ class Processor(object):
             pyramid_oereb.lib.records.real_estate.RealEstateRecord: The updated extract.
         """
         real_estate.plan_for_land_register.get_full_wms_url(real_estate, format)
+        real_estate.plan_for_land_register_main_page.get_full_wms_url(real_estate, format)
         if images:
             real_estate.plan_for_land_register.download_wms_content()
+            real_estate.plan_for_land_register_main_page.download_wms_content()
 
         for public_law_restriction in real_estate.public_law_restrictions:
             public_law_restriction.view_service.get_full_wms_url(real_estate, format)

--- a/pyramid_oereb/lib/records/view_service.py
+++ b/pyramid_oereb/lib/records/view_service.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-import re
 import warnings
 import logging
 import requests
 
 from pyramid_oereb.lib.records.image import ImageRecord
-from pyramid_oereb.lib.url import add_url_params
+from pyramid_oereb.lib.url import add_url_params, parse_url
 from pyramid_oereb.lib.url import uri_validator
 from pyramid_oereb.lib.config import Config
 from shapely.geometry.point import Point
@@ -303,8 +302,9 @@ class ViewServiceRecord(object):
         Returns:
             set of two shapely.geometry.point.Point: min and max coordinates of bounding box.
         """
-        match = re.search('BBOX=((\d+,?)+)', wms_url)
-        if match is None or len(match.groups()) != 2:
+        url, params = parse_url(wms_url)
+        bbox = params.get('BBOX')
+        if bbox is None or len(bbox[0].split(',')) != 4:
             return None, None
-        points = map(float, match.group(1).split(','))
-        return Point(points[0], points[1]), Point(points[2], points[3])
+        points = bbox[0].split(',')
+        return Point(float(points[0]), float(points[1])), Point(float(points[2]), float(points[3]))

--- a/pyramid_oereb/lib/records/view_service.py
+++ b/pyramid_oereb/lib/records/view_service.py
@@ -302,7 +302,7 @@ class ViewServiceRecord(object):
         Returns:
             set of two shapely.geometry.point.Point: min and max coordinates of bounding box.
         """
-        url, params = parse_url(wms_url)
+        _, params = parse_url(wms_url)
         bbox = params.get('BBOX')
         if bbox is None or len(bbox[0].split(',')) != 4:
             return None, None

--- a/pyramid_oereb/lib/records/view_service.py
+++ b/pyramid_oereb/lib/records/view_service.py
@@ -226,6 +226,7 @@ class ViewServiceRecord(object):
             "WIDTH": int(map_size[0]),
             "HEIGHT": int(map_size[1])
         })
+        self.calculate_ns()
         return self.reference_wms
 
     def download_wms_content(self):

--- a/pyramid_oereb/lib/records/view_service.py
+++ b/pyramid_oereb/lib/records/view_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import re
 import warnings
 import logging
 import requests
@@ -67,9 +67,7 @@ class ViewServiceRecord(object):
     # Attributes defined while processing
     image = None    # map image resulting from calling the wms link - binary
 
-    def __init__(self, reference_wms, layer_index, layer_opacity, legend_at_web=None, legends=None,
-                 min_NS03=None, max_NS03=None,
-                 min_NS95=None, max_NS95=None):
+    def __init__(self, reference_wms, layer_index, layer_opacity, legend_at_web=None, legends=None):
         """
 
         Args:
@@ -78,14 +76,6 @@ class ViewServiceRecord(object):
             layer_opacity (float): Opacity of layer. Value from 0.0 to 1.0.
             legend_at_web (uri): The link URL to the actual legend service (WMS get legend)
             legends (list of LegendEntry): A list of all relevant legend entries.
-            min_NS03 (shapely.geometry.point.Point): Minimal value of map extent (bounding box)
-                in EPSG:21781 (NS03).
-            max_NS03 (shapely.geometry.point.Point): Maximal value of map extent (bounding box)
-                in EPSG:21781 (NS03).
-            min_NS95 (shapely.geometry.point.Point): Minimal value of map extent (bounding box)
-                in EPSG:2056 (NS95).
-            max_NS95 (shapely.geometry.point.Point): Maximal value of map extent (bounding box)
-                in EPSG:2056 (NS95).
         """
         self.reference_wms = reference_wms
         self.legend_at_web = legend_at_web
@@ -93,13 +83,13 @@ class ViewServiceRecord(object):
         self.layer_index = self.sanitize_layer_index(layer_index)
         self.layer_opacity = self.sanitize_layer_opacity(layer_opacity)
 
-        self.check_min_max_attributes(min_NS03, 'min_NS03', max_NS03, 'max_NS03')
-        self.min_NS03 = min_NS03
-        self.max_NS03 = max_NS03
-
-        self.check_min_max_attributes(min_NS95, 'min_NS95', max_NS95, 'max_NS95')
-        self.min_NS95 = min_NS95
-        self.max_NS95 = max_NS95
+        self.min_NS03 = None
+        self.max_NS03 = None
+        self.min_NS95 = None
+        self.max_NS95 = None
+        self.calculate_ns()
+        self.check_min_max_attributes(self.min_NS03, 'min_NS03', self.max_NS03, 'max_NS03')
+        self.check_min_max_attributes(self.min_NS95, 'min_NS95', self.max_NS95, 'max_NS95')
 
         if legends is None:
             self.legends = []
@@ -110,8 +100,6 @@ class ViewServiceRecord(object):
 
     @staticmethod
     def sanitize_layer_index(layer_index):
-        if layer_index is None:
-            return 1
         if layer_index and not isinstance(layer_index, int):
             warnings.warn('Type of "layer_index" should be "int"')
         if layer_index < -1000 or layer_index > 1000:
@@ -123,8 +111,6 @@ class ViewServiceRecord(object):
 
     @staticmethod
     def sanitize_layer_opacity(layer_opacity):
-        if layer_opacity is None:
-            return 0.75
         if layer_opacity and not isinstance(layer_opacity, float):
             warnings.warn('Type of "layer_opacity" should be "float"')
         if layer_opacity < 0.0 or layer_opacity > 1.0:
@@ -298,3 +284,26 @@ class ViewServiceRecord(object):
                 break
         if not already_exist:
             self.legends.append(legend)
+
+    def calculate_ns(self):
+        srid = Config.get_crs()
+        if srid == u'epsg:2056':
+            self.min_NS95, self.max_NS95 = self.get_bbox_from_url(self.reference_wms)
+        if srid == u'epsg:21781':
+            self.min_NS03, self.max_NS03 = self.get_bbox_from_url(self.reference_wms)
+
+    @staticmethod
+    def get_bbox_from_url(wms_url):
+        """
+        Parses wms url for BBOX parameter an returns these points as suitable values for ViewServiceRecord.
+        Args:
+            wms_url (str): wms url which includes a BBOX parameter to parse.
+
+        Returns:
+            set of two shapely.geometry.point.Point: min and max coordinates of bounding box.
+        """
+        match = re.search('BBOX=((\d+,?)+)', wms_url)
+        if match is None or len(match.groups()) != 2:
+            return None, None
+        points = map(float, match.group(1).split(','))
+        return Point(points[0], points[1]), Point(points[2], points[3])

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -197,18 +197,16 @@ pyramid_oereb:
   # bound to the source. The model must implement the same field names and information as the default model
   # does.
   real_estate:
-    view_service:
-      # WMS URL to query the plan for land register
+    plan_for_land_register:
+      # WMS URL to query the plan for land register used for all themes pages
       reference_wms: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&STYLES=default&SRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
-      layer_index: 1
-      layer_opacity: 0.25
-      # Legend is optional
-      # legend_at_web:
-    # Overrides for main page of export.
-    # If a value cannot be found here, values from real_estate (parent of this attribute) will be used instead.
-    main_page:
-      view_service:
-        layer_opacity: 0.5
+      layer_index: 0
+      layer_opacity: 1.0
+    plan_for_land_register_main_page:
+      # WMS URL to query the plan for land register specially for static extracts overview page
+      reference_wms: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&STYLES=default&SRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&WIDTH=493&HEIGHT=280&FORMAT=image/png&LAYERS=ch.swisstopo-vd.amtliche-vermessung
+      layer_index: 0
+      layer_opacity: 1.0
     visualisation:
       method: pyramid_oereb.standard.hook_methods.produce_sld_content
       # Note: these parameters must fit to the attributes provided by the RealEstateRecord!!!!
@@ -361,6 +359,9 @@ pyramid_oereb:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -386,6 +387,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -411,6 +415,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -436,6 +443,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -461,6 +471,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -486,6 +499,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -511,6 +527,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -536,6 +555,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -561,6 +583,9 @@ pyramid_oereb:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -586,6 +611,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -611,6 +639,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -636,6 +667,9 @@ pyramid_oereb:
       language: de
       federal: true
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 0.75
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -661,6 +695,9 @@ pyramid_oereb:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -686,6 +723,9 @@ pyramid_oereb:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -711,6 +751,9 @@ pyramid_oereb:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -736,6 +779,9 @@ pyramid_oereb:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:
@@ -761,6 +807,9 @@ pyramid_oereb:
       language: de
       federal: false
       standard: true
+      view_service:
+        layer_index: 1
+        layer_opacity: 1.0
       source:
         class: pyramid_oereb.standard.sources.plr.DatabaseSource
         params:

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -106,7 +106,7 @@ class PlrWebservice(object):
                 u'municipality': [record.fosnr for record in self._municipality_reader.read()],
                 u'flavour': Config.get_flavour(),
                 u'language': Config.get_language(),
-                u'crs': Config.get_crs()
+                u'crs': [Config.get_crs()]
             }
         }
 

--- a/tests/contrib/print_proxy/resources/expected_getspec_extract.json
+++ b/tests/contrib/print_proxy/resources/expected_getspec_extract.json
@@ -764,12 +764,7 @@
     "ReferenceWMS": "http://dev2.geowms.bl.ch/?STYLES=default&LAYERS=grundbuchplan_gebaeude_nicht_gefuellt_group&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415"
   },
   "CantonalLogoRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/logo/canton",
-  "Certification": [
-    {
-      "Text": "Referenz zur kantonsspezifischen Gesetzesgrundlage bez\u00fcglich Beglaubigungen.",
-      "Language": "de"
-    }
-  ],
+  "Certification": "Referenz zur kantonsspezifischen Gesetzesgrundlage bez\u00fcglich Beglaubigungen.",
   "RealEstate_Canton": "BL",
   "PLRCadastreAuthority_Name": "Amt f\u00fcr Geoinformation",
   "RealEstate_IdentDN": "BL0200002766",

--- a/tests/contrib/print_proxy/resources/expected_getspec_extract.json
+++ b/tests/contrib/print_proxy/resources/expected_getspec_extract.json
@@ -1,11 +1,5 @@
 {
-  "Certification": "Referenz zur kantonsspezifischen Gesetzesgrundlage bez\u00fcglich Beglaubigungen.",
-  "CertificationAtWeb": [{"Language": "de", "Text": "https://oereb.bl.ch/certification/de"}],
   "GeneralInformation": "Der Inhalt des \u00d6REB-Katasters wird als bekannt vorausgesetzt. Der Kanton Basel-Landschaft ist f\u00fcr die Genauigkeit und Verl\u00e4sslichkeit der gesetzgebenden Dokumente in elektronischer Form nicht haftbar. Der Auszug hat rein informativen Charakter und begr\u00fcndet insbesondere keine Rechte und Pflichten. Rechtsverbindlich sind diejenigen Dokumente, welche rechtskr\u00e4ftig verabschiedet oder ver\u00f6ffentlicht worden sind. Mit der Beglaubigung des Auszugs wird die \u00dcbereinstimmung des Auszugs mit dem \u00d6REB-Kataster zum Zeitpunkt der Auszugserstellung best\u00e4tigt.",
-  "RealEstate_PlanForLandRegisterMainPage": {
-      "ReferenceWMS": "http://dev2.geowms.bl.ch/?STYLES=default&LAYERS=grundbuchplan_gebaeude_nicht_gefuellt_group&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-      "LayerOpacity": 0.5
-  },
   "RealEstate_RestrictionOnLandownership": [
     {
       "Information": "",
@@ -95,9 +89,9 @@
           "OfficialNumber": "400.11",
           "Lawstatus_Code": "inForce",
           "Title": "Verordnung zum Raumplanungs- und Baugesetz (RBV)",
-          "Abbreviation": "RBV",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei",
           "Canton": "BL",
+          "Abbreviation": "RBV",
           "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/2032?locale=de",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
@@ -106,9 +100,9 @@
           "OfficialNumber": "700",
           "Lawstatus_Code": "inForce",
           "Title": "Bundesgesetz \u00fcber die Raumplanung (Raumplanungsgesetz, RPG)",
-          "Abbreviation": "Raumplanungsgesetz, RPG",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.bk.admin.ch%2F",
           "Canton": "BL",
+          "Abbreviation": "Raumplanungsgesetz, RPG",
           "TextAtWeb": "http://www.lexfind.ch/dtah/155346/2",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
@@ -117,9 +111,9 @@
           "OfficialNumber": "400",
           "Lawstatus_Code": "inForce",
           "Title": "Raumplanungs- und Baugesetz (RBG)",
-          "Abbreviation": "RBG",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei",
           "Canton": "BL",
+          "Abbreviation": "RBG",
           "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1964?locale=de",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
@@ -234,24 +228,24 @@
         {
           "PartInPercent": "73.0%",
           "Information": "Industrie- und Gewerbezone",
-          "AreaShare": "87380.21 m²",
           "TypeCode": "108000",
+          "AreaShare": "87380.21 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/LandUsePlans/108000",
           "Geom_Type": "AreaShare"
         },
         {
           "PartInPercent": "6.2%",
           "Information": "Rheinuferzone",
-          "AreaShare": "7379.93 m²",
           "TypeCode": "130004",
+          "AreaShare": "7379.93 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/LandUsePlans/130004",
           "Geom_Type": "AreaShare"
         },
         {
           "PartInPercent": "5.1%",
           "Information": "Arch\u00e4ologische Schutzzone",
-          "AreaShare": "6125.68 m²",
           "TypeCode": "219106",
+          "AreaShare": "6125.68 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/LandUsePlans/219106",
           "Geom_Type": "AreaShare"
         }
@@ -320,9 +314,9 @@
           "OfficialNumber": "814.01",
           "Lawstatus_Code": "inForce",
           "Title": "Bundesgesetz \u00fcber den Umweltschutz (Umweltschutzgesetz, USG)",
-          "Abbreviation": "Umweltschutzgesetz, USG",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.bk.admin.ch%2F",
           "Canton": "BL",
+          "Abbreviation": "Umweltschutzgesetz, USG",
           "TextAtWeb": "http://www.lexfind.ch/dtah/155395/2",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
@@ -331,9 +325,9 @@
           "OfficialNumber": "814.680",
           "Lawstatus_Code": "inForce",
           "Title": "Verordnung \u00fcber die Sanierung von belasteten Standorten (Altlasten-Verordnung, AltlV)",
-          "Abbreviation": "Altlasten-Verordnung, AltlV",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.bk.admin.ch%2F",
           "Canton": "BL",
+          "Abbreviation": "Altlasten-Verordnung, AltlV",
           "TextAtWeb": "http://www.lexfind.ch/dtah/147568/2",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
@@ -342,9 +336,9 @@
           "OfficialNumber": "780",
           "Lawstatus_Code": "inForce",
           "Title": "Umweltschutzgesetz Basel-Landschaft (USG BL)",
-          "Abbreviation": "USG BL",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei",
           "Canton": "BL",
+          "Abbreviation": "USG BL",
           "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1337?locale=de",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
@@ -353,9 +347,9 @@
           "OfficialNumber": "780.11",
           "Lawstatus_Code": "inForce",
           "Title": "Verordnung \u00fcber den Umweltschutz (USV)",
-          "Abbreviation": "USV",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei",
           "Canton": "BL",
+          "Abbreviation": "USV",
           "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/273?locale=de",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
@@ -390,32 +384,32 @@
         {
           "PartInPercent": "51.8%",
           "Information": "Betriebsstandort. Belastet, keine sch\u00e4dlichen oder l\u00e4stigen Einwirkungen zu erwarten",
-          "AreaShare": "61999.23 m²",
           "TypeCode": "StaoTyp2_StatusAltlV1",
+          "AreaShare": "61999.23 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/ContaminatedSites/StaoTyp2_StatusAltlV1",
           "Geom_Type": "AreaShare"
         },
         {
           "PartInPercent": "12.1%",
           "Information": "Betriebsstandort. Belastet, weder \u00fcberwachungs- noch sanierungsbed\u00fcrftig",
-          "AreaShare": "14503.04 m²",
           "TypeCode": "StaoTyp2_StatusAltlV3",
+          "AreaShare": "14503.04 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/ContaminatedSites/StaoTyp2_StatusAltlV3",
           "Geom_Type": "AreaShare"
         },
         {
           "PartInPercent": "4.8%",
           "Information": "Betriebsstandort. Belastet,  \u00fcberwachungsbed\u00fcrftig",
-          "AreaShare": "5764.33 m²",
           "TypeCode": "StaoTyp2_StatusAltlV4",
+          "AreaShare": "5764.33 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/ContaminatedSites/StaoTyp2_StatusAltlV4",
           "Geom_Type": "AreaShare"
         },
         {
           "PartInPercent": "1.0%",
           "Information": "Unfallstandort. Belastet, keine sch\u00e4dlichen oder l\u00e4stigen Einwirkungen zu erwarten",
-          "AreaShare": "1210.49 m²",
           "TypeCode": "StaoTyp3_StatusAltlV1",
+          "AreaShare": "1210.49 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/ContaminatedSites/StaoTyp3_StatusAltlV1",
           "Geom_Type": "AreaShare"
         }
@@ -478,9 +472,9 @@
           "OfficialNumber": "780",
           "Lawstatus_Code": "inForce",
           "Title": "Umweltschutzgesetz Basel-Landschaft (USG BL)",
-          "Abbreviation": "USG BL",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.baselland.ch%2Fpolitik-und-behorden%2Fbesondere-behorden%2Flandeskanzlei",
           "Canton": "BL",
+          "Abbreviation": "USG BL",
           "TextAtWeb": "http://bl.clex.ch/frontend/versions/pdf_file_with_annex/1337?locale=de",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Landeskanzlei"
@@ -489,9 +483,9 @@
           "OfficialNumber": "814.41",
           "Lawstatus_Code": "inForce",
           "Title": "L\u00e4rmschutz-Verordnung (LSV)",
-          "Abbreviation": "LSV",
           "ResponsibleOffice_OfficeAtWeb": "https%3A%2F%2Fwww.bk.admin.ch%2F",
           "Canton": "BL",
+          "Abbreviation": "LSV",
           "TextAtWeb": "http://www.lexfind.ch/dtah/147569/2",
           "Lawstatus_Text": "in Kraft",
           "ResponsibleOffice_Name": "Bundeskanzlei"
@@ -516,8 +510,8 @@
         {
           "PartInPercent": "73.0%",
           "Information": "Empfindlichkeitsstufe ES IV",
-          "AreaShare": "87381.15 m²",
           "TypeCode": "ES_IV",
+          "AreaShare": "87381.15 m\u00b2",
           "SymbolRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/symbol/NoiseSensitivityLevels/ES_IV",
           "Geom_Type": "AreaShare"
         }
@@ -673,6 +667,12 @@
   "RealEstate_Municipality": "Birsfelden",
   "FederalLogoRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/logo/confederation",
   "ExtractIdentifier": "e2ec795b-91f8-4827-8549-808ca7f25251",
+  "CertificationAtWeb": [
+    {
+      "Text": "https://oereb.bl.ch/certification/de",
+      "Language": "de"
+    }
+  ],
   "ExclusionOfLiability": [
     {
       "Content": "Der Kataster der belasteten Standorte (KbS) wurde anhand der vom Bundesamt f\u00fcr Umwelt BAFU festgelegten Kriterien erstellt und wird fortw\u00e4hrend aufgrund neuer Erkenntnisse (z.B. Untersuchungen) aktualisiert. Die im KbS eingetragenen Fl\u00e4chen k\u00f6nnen vom tats\u00e4chlichen Ausmass der Belastung abweichen. Erscheint ein Grundst\u00fcck nicht im KbS, besteht keine absolute Gew\u00e4hr, dass das Areal frei von jeglichen Abfall- oder Schadstoffbelastungen ist. Bahnbetrieblich, milit\u00e4risch und f\u00fcr die Luftfahrt genutzte Standorte liegen im Zust\u00e4ndigkeitsbereich des Bundes. F\u00fcr weitere Informationen wenden Sie sich an die kantonale Altlastenfachstelle, Amt f\u00fcr Umweltschutz und Energie (www.aue.bl.ch).",
@@ -680,7 +680,7 @@
     }
   ],
   "LogoPLRCadastreRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/logo/oereb",
-  "RealEstate_LandRegistryArea": "119681.0 m²",
+  "RealEstate_LandRegistryArea": "119681.0 m\u00b2",
   "RealEstate_Type": "RealEstate",
   "Footer": "16.02.2018   11:54:24   e2ec795b-91f8-4827-8549-808ca7f25251",
   "Glossary": [
@@ -759,8 +759,17 @@
   "PLRCadastreAuthority_City": "Liestal",
   "PLRCadastreAuthority_PostalCode": 4410,
   "PLRCadastreAuthority_OfficeAtWeb": "http://www.agi.bl.ch",
-  "legend": "",
+  "RealEstate_PlanForLandRegisterMainPage": {
+    "LayerOpacity": 0.5,
+    "ReferenceWMS": "http://dev2.geowms.bl.ch/?STYLES=default&LAYERS=grundbuchplan_gebaeude_nicht_gefuellt_group&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415"
+  },
   "CantonalLogoRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/logo/canton",
+  "Certification": [
+    {
+      "Text": "Referenz zur kantonsspezifischen Gesetzesgrundlage bez\u00fcglich Beglaubigungen.",
+      "Language": "de"
+    }
+  ],
   "RealEstate_Canton": "BL",
   "PLRCadastreAuthority_Name": "Amt f\u00fcr Geoinformation",
   "RealEstate_IdentDN": "BL0200002766",

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -54,4 +54,7 @@ def test_mapfish_print_entire_extract():
     pdf_to_join = set()
     printable_extract = extract()
     renderer.convert_to_printable_extract(printable_extract, geometry(), pdf_to_join)
+    f = open('/tmp/printable_extract.json', 'w')
+    f.write(json.dumps(printable_extract))
+    f.close()
     assert printable_extract == expected_printable_extract()

--- a/tests/readers/test_real_estate.py
+++ b/tests/readers/test_real_estate.py
@@ -4,7 +4,6 @@ import pytest
 from pyramid_oereb.lib.records.real_estate import RealEstateRecord
 from pyramid_oereb.lib.sources import Base
 from pyramid_oereb.lib.readers.real_estate import RealEstateReader
-from shapely.geometry.point import Point
 
 
 @pytest.mark.run(order=2)
@@ -32,20 +31,3 @@ def test_read(param, config):
     record = records[0]
     assert isinstance(record, RealEstateRecord)
     assert record.fosnr == 1234
-
-
-def test_get_bbox():
-    with_bbox = 'https://host/?&SRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&' \
-                'WIDTH=493&HEIGHT=280&FORMAT=image/png'
-    p1, p2 = RealEstateReader.get_bbox(with_bbox)
-    assert isinstance(p1, Point)
-    assert p1.x == 2475000.0
-    assert p1.y == 1065000.0
-    assert isinstance(p2, Point)
-    assert p2.x == 2850000.0
-    assert p2.y == 1300000.0
-
-    no_bbox = 'https://host/?&SRS=EPSG:2056WIDTH=493&HEIGHT=280&FORMAT=image/png'
-    p3, p4 = RealEstateReader.get_bbox(no_bbox)
-    assert p3 is None
-    assert p4 is None

--- a/tests/records/test_view_service.py
+++ b/tests/records/test_view_service.py
@@ -17,20 +17,12 @@ def test_init():
                                1,
                                1.0,
                                'http://www.test.url.ch',
-                               None,
-                               Point(2608000, 1261000),
-                               Point(2609000, 1262000),
-                               Point(2608000, 1261000),
-                               Point(2609000, 1262000))
+                               None)
     assert isinstance(record.reference_wms, str)
     assert isinstance(record.layer_index, int)
     assert isinstance(record.layer_opacity, float)
     assert isinstance(record.legend_at_web, str)
     assert isinstance(record.legends, list)
-    assert isinstance(record.min_NS03, Point)
-    assert isinstance(record.max_NS03, Point)
-    assert isinstance(record.min_NS95, Point)
-    assert isinstance(record.max_NS95, Point)
 
 
 def test_init_with_relation():
@@ -46,20 +38,12 @@ def test_init_with_relation():
                                1,
                                1.0,
                                'http://www.test.url.ch',
-                               legend_records,
-                               Point(2608000, 1261000),
-                               Point(2609000, 1262000),
-                               Point(2608000, 1261000),
-                               Point(2609000, 1262000))
+                               legend_records)
     assert isinstance(record.reference_wms, str)
     assert isinstance(record.layer_index, int)
     assert isinstance(record.layer_opacity, float)
     assert isinstance(record.legend_at_web, str)
     assert isinstance(record.legends, list)
-    assert isinstance(record.min_NS03, Point)
-    assert isinstance(record.max_NS03, Point)
-    assert isinstance(record.min_NS95, Point)
-    assert isinstance(record.max_NS95, Point)
 
 
 def test_invalid_layer_index_arguments():
@@ -80,86 +64,57 @@ def test_invalid_layer_layer_opacity():
         ViewServiceRecord('http://example.com', 1, 1)
 
 
-def test_min_max_attributes():
+def test_check_min_max_attributes():
     min_val = Point(1, 1)
     max_val = Point(2, 2)
 
     # test None values, expect no error
-    ViewServiceRecord('http://www.test.url.ch',
-                      1,
-                      1.0,
-                      'http://www.test.url.ch',
-                      None,
-                      None,
-                      None,
-                      None,
-                      None)
+    ViewServiceRecord.check_min_max_attributes(None, 'test1', None, 'test2')
 
     # combinations of value + None
     with pytest.raises(AttributeError):
-        ViewServiceRecord('http://www.test.url.ch',
-                          1,
-                          1.0,
-                          'http://www.test.url.ch',
-                          None,
-                          min_val,
-                          None,
-                          None,
-                          None)
-
+        ViewServiceRecord.check_min_max_attributes(min_val, 'test1', None, 'test2')
     with pytest.raises(AttributeError):
-        ViewServiceRecord('http://www.test.url.ch',
-                          1,
-                          1.0,
-                          'http://www.test.url.ch',
-                          None,
-                          None,
-                          min_val,
-                          None,
-                          None)
-
-    with pytest.raises(AttributeError):
-        ViewServiceRecord('http://www.test.url.ch',
-                          1,
-                          1.0,
-                          'http://www.test.url.ch',
-                          None,
-                          None,
-                          None,
-                          min_val,
-                          None)
-
-    with pytest.raises(AttributeError):
-        ViewServiceRecord('http://www.test.url.ch',
-                          1,
-                          1.0,
-                          'http://www.test.url.ch',
-                          None,
-                          None,
-                          None,
-                          None,
-                          min_val)
+        ViewServiceRecord.check_min_max_attributes(None, 'test1', min_val, 'test2')
 
     # type error
     with pytest.raises(AttributeError):
-        ViewServiceRecord('http://www.test.url.ch',
-                          1,
-                          1.0,
-                          'http://www.test.url.ch',
-                          None,
-                          1,
-                          2,
-                          3,
-                          4)
+        ViewServiceRecord.check_min_max_attributes(1, 'test1', 2, 'test2')
 
     # inverted values
     with pytest.raises(AttributeError):
-        ViewServiceRecord('http://www.test.url.ch',
-                          1,
-                          1.0,
-                          'http://www.test.url.ch',
-                          None,
-                          max_val,
-                          min_val,
-                          max_val,
-                          min_val)
+        ViewServiceRecord.check_min_max_attributes(max_val, 'test1', min_val, 'test2')
+
+
+def test_get_bbox_from_url():
+    with_bbox = 'https://host/?&SRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&' \
+                'WIDTH=493&HEIGHT=280&FORMAT=image/png'
+    p1, p2 = ViewServiceRecord.get_bbox_from_url(with_bbox)
+    assert isinstance(p1, Point)
+    assert p1.x == 2475000.0
+    assert p1.y == 1065000.0
+    assert isinstance(p2, Point)
+    assert p2.x == 2850000.0
+    assert p2.y == 1300000.0
+
+    no_bbox = 'https://host/?&SRS=EPSG:2056WIDTH=493&HEIGHT=280&FORMAT=image/png'
+    p3, p4 = ViewServiceRecord.get_bbox_from_url(no_bbox)
+    assert p3 is None
+    assert p4 is None
+
+
+def test_view_service_correct_init_ns(config):
+    with_bbox = 'https://host/?&SRS=EPSG:2056&BBOX=2475000,1065000,2850000,1300000&' \
+                'WIDTH=493&HEIGHT=280&FORMAT=image/png'
+    test_view_service = ViewServiceRecord(with_bbox, 1, 1.0, 'http://www.test.url.ch', None)
+    assert isinstance(test_view_service.min_NS95, Point)
+    assert test_view_service.min_NS95.x == 2475000.0
+    assert test_view_service.min_NS95.y == 1065000.0
+    assert isinstance(test_view_service.max_NS95, Point)
+    assert test_view_service.max_NS95.x == 2850000.0
+    assert test_view_service.max_NS95.y == 1300000.0
+
+    no_bbox = 'https://host/?&SRS=EPSG:2056WIDTH=493&HEIGHT=280&FORMAT=image/png'
+    test_view_service_no_bbox = ViewServiceRecord(no_bbox, 1, 1.0, 'http://www.test.url.ch', None)
+    assert test_view_service_no_bbox.min_NS95 is None
+    assert test_view_service_no_bbox.max_NS95 is None

--- a/tests/resources/test_config.yml
+++ b/tests/resources/test_config.yml
@@ -31,7 +31,7 @@ pyramid_oereb:
     proxy:
       http: http://my.proxy.org
       https:
-
+  srid: 2056
   plrs:
     - name: plr87
       code: LandUsePlans
@@ -42,12 +42,11 @@ pyramid_oereb:
       code: MotorwaysProjectPlaningZones
 
   real_estate:
-      view_service:
-        reference_wms: https://wms.ch/?BBOX=2475000,1065000,2850000,1300000
-        layer_index: 1
-        layer_opacity: 0.25
-      main_page:
-        view_service:
-          layer_index: 2
-          layer_opacity: 0.5
-          not_in_config: does not matter
+    plan_for_land_register:
+      reference_wms: https://wms.ch/?BBOX=2475000,1065000,2850000,1300000
+      layer_index: 1
+      layer_opacity: 0.25
+    plan_for_land_register_main_page:
+      reference_wms: https://wms.ch/?BBOX=2475000,1065000,2850000,1300000
+      layer_index: 2
+      layer_opacity: 0.5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,12 +141,11 @@ def test_get_layer_config():
     assert layer_opacity is None
 
 
-def get_real_estate_main_page_config():
+def test_get_real_estate_main_page_config():
     Config._config = None
     Config.init('./tests/resources/test_config.yml', 'pyramid_oereb')
-    main_page_config = Config.get_real_estate_config()
-    view_service = main_page_config.get('view_service')
-    assert view_service.get('reference_wms') == 'https://wms.ch/?BBOX=2475000,1065000,2850000,1300000'
-    assert view_service.get('layer_index') == 2
-    assert view_service.get('layer_opacity') == 0.5
-    assert view_service.get('not_in_config') is None
+    plan_for_land_register_main_page_config = Config.get_plan_for_land_register_main_page_config()
+    assert plan_for_land_register_main_page_config.get('reference_wms') == 'https://wms.ch/?BBOX=2475000,' \
+                                                                           '1065000,2850000,1300000'
+    assert plan_for_land_register_main_page_config.get('layer_index') == 2
+    assert plan_for_land_register_main_page_config.get('layer_opacity') == 0.5


### PR DESCRIPTION
While testing I had a more detailed look on the behaviour around the ViewService.

It turned out, that sanitize methods at ViewServiceRecord were setting standard values silently. This is a little bit of bad behaviour. I added a dedicated configuration for every theme in the standard_yaml and in addition for the real estate I changed the attribute names and structure of config to a more logic way (also using the correct attribute names for this from specification). To make the code more straight forward I moved all calculation methods from RealEstateReader to ViewServiceRecord.

Well this is my opinion. But I think its a little less scrambled now.