### PR TITLE
Fix xml rendering

### DIFF
--- a/pyramid_oereb/lib/renderer/extract/templates/xml/document.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/document.xml
@@ -32,7 +32,7 @@
 <%include file="article.xml" args="article=article"/>
 %endfor
 %for reference in document.references:
-<data:Reference xsi:type="${get_document_type(reference)}">
+<data:Reference xsi:type="data:Document">
     <%include file="document.xml" args="document=reference"/>
 </data:Reference>
 %endfor

--- a/pyramid_oereb/lib/renderer/extract/templates/xml/public_law_restriction.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/public_law_restriction.xml
@@ -50,7 +50,7 @@
         <%include file="view_service.xml" args="map=public_law_restriction.view_service"/>
     </data:Map>
     %for document in public_law_restriction.documents:
-    <data:LegalProvisions xsi:type="${get_document_type(document)}">
+    <data:LegalProvisions xsi:type="data:Document">
         <%include file="document.xml" args="document=document"/>
     </data:LegalProvisions>
     %endfor

--- a/pyramid_oereb/lib/renderer/extract/templates/xml/view_service.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/view_service.xml
@@ -19,16 +19,32 @@
 %endfor
 %endif
 %if map.min_NS03 is not None:
-<data:min_NS03>${map.min_NS03.x} ${map.min_NS03.y}</data:min_NS03>
+<data:min_NS03>
+    <gml:Point>
+        <gml:pos>${map.min_NS03.x} ${map.min_NS03.y}</gml:pos>
+    </gml:Point>
+</data:min_NS03>
 %endif
 %if map.max_NS03 is not None:
-<data:max_NS03>${map.max_NS03.x} ${map.max_NS03.y}</data:max_NS03>
+<data:max_NS03>
+    <gml:Point>
+        <gml:pos>${map.max_NS03.x} ${map.max_NS03.y}</gml:pos>
+    </gml:Point>
+</data:max_NS03>
 %endif
 %if map.min_NS95 is not None:
-<data:min_NS95>${map.min_NS95.x} ${map.min_NS95.y}</data:min_NS95>
+<data:min_NS95>
+    <gml:Point>
+        <gml:pos>${map.min_NS95.x} ${map.min_NS95.y}</gml:pos>
+    </gml:Point>
+</data:min_NS95>
 %endif
 %if map.max_NS95 is not None:
-<data:max_NS95>${map.max_NS95.x} ${map.max_NS95.y}</data:max_NS95>
+<data:max_NS95>
+    <gml:Point>
+        <gml:pos>${map.max_NS95.x} ${map.max_NS95.y}</gml:pos>
+    </gml:Point>
+</data:max_NS95>
 %endif
 <data:layerIndex>${map.layer_index}</data:layerIndex>
 <data:layerOpacity>${map.layer_opacity}</data:layerOpacity>

--- a/pyramid_oereb/lib/renderer/extract/templates/xml/view_service.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/view_service.xml
@@ -18,8 +18,6 @@
 </data:OtherLegend>
 %endfor
 %endif
-<data:layerIndex>${map.layer_index}</data:layerIndex>
-<data:layerOpacity>${map.layer_opacity}</data:layerOpacity>
 %if map.min_NS03 is not None:
 <data:min_NS03>${map.min_NS03.x} ${map.min_NS03.y}</data:min_NS03>
 %endif
@@ -32,3 +30,5 @@
 %if map.max_NS95 is not None:
 <data:max_NS95>${map.max_NS95.x} ${map.max_NS95.y}</data:max_NS95>
 %endif
+<data:layerIndex>${map.layer_index}</data:layerIndex>
+<data:layerOpacity>${map.layer_opacity}</data:layerOpacity>

--- a/pyramid_oereb/lib/renderer/extract/xml_.py
+++ b/pyramid_oereb/lib/renderer/extract/xml_.py
@@ -4,7 +4,6 @@ from pyramid.path import AssetResolver
 
 from pyramid.response import Response
 
-from pyramid_oereb.lib.records.documents import LegalProvisionRecord
 from pyramid_oereb.lib.renderer import Base
 from mako import exceptions
 

--- a/pyramid_oereb/lib/renderer/extract/xml_.py
+++ b/pyramid_oereb/lib/renderer/extract/xml_.py
@@ -89,19 +89,3 @@ class Renderer(Base):
         """
         self._gml_id += 1
         return 'gml{0}'.format(self._gml_id)
-
-    @classmethod
-    def _get_document_type(cls, document):
-        """
-        Returns the documents xsi type.
-
-        Args:
-            document (pyramid_oereb.lib.records.documents.DocumentRecord): The document record.
-
-        Returns:
-            str: The documents xsi type
-
-        """
-        if isinstance(document, LegalProvisionRecord):
-            return 'data:LegalProvisions'
-        return 'data:Document'

--- a/tests/renderer/test_xml.py
+++ b/tests/renderer/test_xml.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
-import datetime
 from shapely.geometry import LineString, Point, Polygon
 
-from pyramid_oereb.lib.records.documents import DocumentRecord, LegalProvisionRecord
-from pyramid_oereb.lib.records.law_status import LawStatusRecord
-from pyramid_oereb.lib.records.office import OfficeRecord
 from pyramid_oereb.lib.renderer.extract.xml_ import Renderer
 from tests.conftest import params
 import pytest

--- a/tests/renderer/test_xml.py
+++ b/tests/renderer/test_xml.py
@@ -17,15 +17,6 @@ def test_get_gml_id():
     assert renderer._get_gml_id() == 'gml3'
 
 
-def test_get_document_type():
-    document = DocumentRecord('Law', LawStatusRecord.from_config('inForce'), datetime.date.today(),
-                              {'de': 'Test'}, OfficeRecord({'de': 'Test'}))
-    legal_provision = LegalProvisionRecord(LawStatusRecord.from_config('inForce'), datetime.date.today(),
-                                           {'de': 'Test'}, OfficeRecord({'de': 'Test'}))
-    assert Renderer._get_document_type(document) == 'data:Document'
-    assert Renderer._get_document_type(legal_provision) == 'data:LegalProvisions'
-
-
 @pytest.mark.parametrize('parameters', params)
 def test_line(parameters, xml_templates):
     line = LineString(((0, 0), (1, 1)))


### PR DESCRIPTION
Some fixes to validate against schema:
- `xsi:type="data:LegalProvisions"` has been removed as it is redundant with the new `DocumentType` attribute => all documents have `xsi:type="data:Document"` now
- The attributes `min_NS03`, `max_NS03`, `min_NS95` and `max_NS95` have to be placed between `OtherLegend` and `layerIndex`
- The coordinates within these attributes have to be wrapped with `gml:Point` and `gml:pos` tags