### PR TITLE
Delete references to deleted _get_document_type function

### DIFF
--- a/pyramid_oereb/lib/renderer/extract/templates/xml/real_estate.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/real_estate.xml
@@ -46,7 +46,7 @@
         <%include file="view_service.xml" args="map=real_estate.plan_for_land_register_main_page"/>
     </data:PlanForLandRegisterMainPage>
 %for reference in real_estate.references:
-    <data:Reference xsi:type="${get_document_type(reference)}">
+    <data:Reference xsi:type="data:Document">
         <%include file="document.xml" args="document=reference"/>
     </data:Reference>
 %endfor

--- a/pyramid_oereb/lib/renderer/extract/xml_.py
+++ b/pyramid_oereb/lib/renderer/extract/xml_.py
@@ -67,7 +67,6 @@ class Renderer(Base):
                 'request': self._request,
                 'get_symbol_ref': self.get_symbol_ref,
                 'get_gml_id': self._get_gml_id,
-                'get_document_type': self._get_document_type,
                 'date_format': '%Y-%m-%dT%H:%M:%S'
             })
             return content


### PR DESCRIPTION
Fixes broken master. Creating a extract fails currently.