### PR TITLE
Todo in records

### DIFF
--- a/pyramid_oereb/lib/records/embeddable.py
+++ b/pyramid_oereb/lib/records/embeddable.py
@@ -20,8 +20,8 @@ class EmbeddableRecord(object):
                 information on the extract.
         """
 
-        # TODO: there is a element called pdf inside the OREB-XML-Aufruf specification in the embeddable
-        # section which is realy mystic, it is documented nowhere!!!
+        # Filling out the 'pdf' attribute with pdf content is currently not supported by pyramid_oereb
+        # More details in PR https://github.com/camptocamp/pyramid_oereb/pull/601
         self.cadaster_state = cadaster_state
         self.cadaster_organisation = cadaster_organisation
         self.data_owner_cadastral_surveying = data_owner_cadastral_surveying

--- a/pyramid_oereb/lib/records/geometry.py
+++ b/pyramid_oereb/lib/records/geometry.py
@@ -94,8 +94,10 @@ class GeometryRecord(object):
                     self._area_share = compensated_area
                     self._test_passed = True
             else:
-                    # TODO: configure a proper error message
-                    log.error('Unknown geometry type')
+                supported_types = ', '.join(point_types + line_types + polygon_types)
+                raise AttributeError(
+                    u'The passed geometry is not supported: {type}. It should be one of: {types}'
+                    .format(type=self.geom.type, types=supported_types))
         self.calculated = True
         return self._test_passed
 

--- a/pyramid_oereb/lib/records/view_service.py
+++ b/pyramid_oereb/lib/records/view_service.py
@@ -233,10 +233,10 @@ class ViewServiceRecord(object):
         Simply downloads the image found behind the URL stored in the instance attribute "reference_wms".
 
         Raises:
-            LookupError: Raised if the response is not code 200
+            LookupError: Raised if the response is not code 200 or content-type
+                doesn't contains type "image".
             AttributeError: Raised if the URL itself isn't valid at all.
         """
-        # TODO: Check better for a image as response than only code 200...
         main_msg = "Image for WMS couldn't be retrieved."
         if uri_validator(self.reference_wms):
             log.debug("Downloading image, url: {url}".format(url=self.reference_wms))
@@ -251,7 +251,8 @@ class ViewServiceRecord(object):
                 log.error(dedicated_msg)
                 raise LookupError(dedicated_msg)
 
-            if response.status_code == 200:
+            content_type = response.headers.get('content-type', '')
+            if response.status_code == 200 and content_type.find('image') > -1:
                 self.image = ImageRecord(response.content)
             else:
                 dedicated_msg = "The image could not be downloaded. URL was: {url}, Response was " \


### PR DESCRIPTION
@jwkaltz I've kept and improved one TODO (see last commit). There is still a mysterious 'pdf' element that is documented nowhere. We should ask the committee that have written this document. 

Also, with the first commit, the '.../full/pdf/...' extract raise now an error. Because an image can't be delivered by the wms server:
```
The image could not be downloaded. URL was: https://wms.geo.admin.ch/?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.1&STYLES=default&SRS=EPSG%3A2056&BBOX=2608528.306829545%2C1261650.4728636362%2C2609230.193170455%2C1262049.1101363637&WIDTH=2055&HEIGHT=1169&FORMAT=image%2Fpng&LAYERS=ch.swisstopo-vd.amtliche-vermessung&sld=http%3A%2F%2Flocalhost%3A6543%2Foereb%2Fsld%3Fegrid%3DCH113928077734,
...
ServiceException>\nmsSLDApplySLDURL: WMS server error. Could not open SLD http://localhost:6543/oereb/sld?egrid=CH113928077734 and save it in a temporary file. Please make sure that the sld url is valid and that the temporary path is set. The temporary path can be defined for example by setting TMPPATH in the map file. Please check the MapServer documentation on temporary path settings.\nmsHTTPExecuteRequests(): HTTP request error. HTTP: request failed with curl error code 7 (Failed to connect to localhost port 6543: Connection refused) for http://localhost:6543/oereb/sld?egrid=CH113928077734\n</ServiceException>\n</ServiceExceptionReport>
```
That's what we want, but that can be annoying to test, to present a demo, etc.