### PR TITLE
fix build for Debian 8 (and other old environments)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ else
     TESTS_SETUP_DB = tests-docker-setup-db
     TESTS_DROP_DB = tests-docker-drop-db
 endif
-
+PIP_UPDATE = $(VENV_BIN)pip install --upgrade pip setuptools
+ 
 SPHINXOPTS =
 SPHINXBUILD = $(VENV_BIN)sphinx-build$(PYTHON_BIN_POSTFIX)
 SPHINXPROJ = OEREB
@@ -44,7 +45,7 @@ BUILDDIR = doc/build
 install: $(PYTHON_VENV)
 
 .venv/timestamp:
-	virtualenv .venv
+	virtualenv --no-site-packages .venv
 	touch $@
 
 .venv/requirements-timestamp: .venv/install-timestamp .venv/timestamp setup.py dev-requirements.txt
@@ -52,6 +53,7 @@ install: $(PYTHON_VENV)
 	touch $@
 
 .venv/install-timestamp: .venv/timestamp setup.py $(INSTALL_REQUIREMENTS)
+	$(PIP_UPDATE)
 	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install --requirement $(INSTALL_REQUIREMENTS)
 	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install --editable .
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
     TESTS_DROP_DB = tests-docker-drop-db
 endif
 PIP_UPDATE = $(VENV_BIN)pip install --upgrade pip setuptools
- 
+
 SPHINXOPTS =
 SPHINXBUILD = $(VENV_BIN)sphinx-build$(PYTHON_BIN_POSTFIX)
 SPHINXPROJ = OEREB

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cryptography==1.9 # for urllib in Debian 8 compatible version, rq.filter: < 2.0
 dicttoxml==1.7.4
 geoalchemy2==0.4.2
 psycopg2==2.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography==1.9 # for urllib in Debian 8 compatible version, rq.filter: < 2.0
 dicttoxml==1.7.4
 geoalchemy2==0.4.2
 psycopg2==2.7.5


### PR DESCRIPTION
Since the usage of urllib3 introduced between versions 1.2.0 and 1.2.1, pyramid_oereb no longer builds on Debian 8 and other systems that have an old version of setuptools.
The cryptography lib version (required from urllib3) requires a recent version of setuptools.

This PR changes the build process, to force the usage of recent version of pip and setuptools.

See also issue #602 .
