### PR TITLE
Use datatype "String" for inhertance mapping

### DIFF
--- a/pyramid_oereb/standard/models/airports_building_lines.py
+++ b/pyramid_oereb/standard/models/airports_building_lines.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'airports_building_lines'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/airports_project_planning_zones.py
+++ b/pyramid_oereb/standard/models/airports_project_planning_zones.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'airports_project_planning_zones'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/airports_security_zone_plans.py
+++ b/pyramid_oereb/standard/models/airports_security_zone_plans.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'airports_security_zone_plans'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/contaminated_civil_aviation_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_civil_aviation_sites.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'contaminated_civil_aviation_sites'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/contaminated_military_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_military_sites.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'contaminated_military_sites'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/contaminated_public_transport_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_public_transport_sites.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'contaminated_public_transport_sites'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/contaminated_sites.py
+++ b/pyramid_oereb/standard/models/contaminated_sites.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'contaminated_sites'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/forest_distance_lines.py
+++ b/pyramid_oereb/standard/models/forest_distance_lines.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'forest_distance_lines'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/forest_perimeters.py
+++ b/pyramid_oereb/standard/models/forest_perimeters.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'forest_perimeters'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/groundwater_protection_sites.py
+++ b/pyramid_oereb/standard/models/groundwater_protection_sites.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'groundwater_protection_sites'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/groundwater_protection_zones.py
+++ b/pyramid_oereb/standard/models/groundwater_protection_zones.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'groundwater_protection_zones'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/land_use_plans.py
+++ b/pyramid_oereb/standard/models/land_use_plans.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'land_use_plans'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/motorways_building_lines.py
+++ b/pyramid_oereb/standard/models/motorways_building_lines.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'motorways_building_lines'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/motorways_project_planing_zones.py
+++ b/pyramid_oereb/standard/models/motorways_project_planing_zones.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'motorways_project_planing_zones'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/noise_sensitivity_levels.py
+++ b/pyramid_oereb/standard/models/noise_sensitivity_levels.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'noise_sensitivity_levels'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/railways_building_lines.py
+++ b/pyramid_oereb/standard/models/railways_building_lines.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'railways_building_lines'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/models/railways_project_planning_zones.py
+++ b/pyramid_oereb/standard/models/railways_project_planning_zones.py
@@ -135,7 +135,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': 'railways_project_planning_zones'}
@@ -144,7 +144,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/templates/plr_integer_primary_keys.py.mako
+++ b/pyramid_oereb/standard/templates/plr_integer_primary_keys.py.mako
@@ -136,7 +136,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': '${schema_name}'}
@@ -145,7 +145,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,

--- a/pyramid_oereb/standard/templates/plr_string_primary_keys.py.mako
+++ b/pyramid_oereb/standard/templates/plr_string_primary_keys.py.mako
@@ -136,7 +136,7 @@ class DocumentBase(Base):
         published_from (datetime.date): The date when the document should be available for
             publishing on extracts. This  directly affects the behaviour of extract
             generation.
-        type (unicode): This is a sqlalchemy related attribute to provide database table
+        type (str): This is a sqlalchemy related attribute to provide database table
             inheritance.
     """
     __table_args__ = {'schema': '${schema_name}'}
@@ -145,7 +145,7 @@ class DocumentBase(Base):
     text_at_web = sa.Column(JSONType, nullable=True)
     law_status = sa.Column(sa.String, nullable=False)
     published_from = sa.Column(sa.Date, nullable=False)
-    type = sa.Column(sa.Unicode, nullable=False)
+    type = sa.Column(sa.String, nullable=False)
     __mapper_args__ = {
         'polymorphic_identity': 'document_base',
         'polymorphic_on': type,


### PR DESCRIPTION
Use datatype `String` instead of `Unicode` for SQLAlchemy inheritance mapping to avoid unicode warnings. Unicode should not be necessary here.