### PR TITLE
Fix JSON for min_NS03, max_NS03, min_NS95 and max_NS95

### DIFF
--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -493,13 +493,13 @@ class Renderer(Base):
         map_dict['LayerIndex'] = map_.layer_index
         map_dict['LayerOpacity'] = map_.layer_opacity
         if map_.min_NS03 is not None:
-            map_dict['min_NS03'] = self.format_point(map_.min_NS03)
+            map_dict['min_NS03'] = self.format_point(map_.min_NS03, 'EPSG:21781')
         if map_.max_NS03 is not None:
-            map_dict['max_NS03'] = self.format_point(map_.max_NS03)
+            map_dict['max_NS03'] = self.format_point(map_.max_NS03, 'EPSG:21781')
         if map_.min_NS95 is not None:
-            map_dict['min_NS95'] = self.format_point(map_.min_NS95)
+            map_dict['min_NS95'] = self.format_point(map_.min_NS95, 'EPSG:2056')
         if map_.max_NS95 is not None:
-            map_dict['max_NS95'] = self.format_point(map_.max_NS95)
+            map_dict['max_NS95'] = self.format_point(map_.max_NS95, 'EPSG:2056')
 
         return map_dict
 
@@ -590,5 +590,8 @@ class Renderer(Base):
         return embeddable_dict
 
     @staticmethod
-    def format_point(point):
-        return {'x': point.x, 'y': point.y}
+    def format_point(point, crs):
+        return {
+            'coordinates': [point.x, point.y],
+            'crs': crs
+        }


### PR DESCRIPTION
Render `min_NS03`, `max_NS03`, `min_NS95` and `max_NS95` according to `PointPropertyType`:

```json
"position": {
    "type": "array",
    "items": {
        "type": "number"
    },
    "minItems": 2
},
"positionArray": {
    "type": "array",
    "items": {
        "$ref": "#/definitions/position"
    }
},
"PointPropertyType": {
    "type": "object",
    "properties": {
        "type": {
            "enum": [
                "Point"
            ]
        },
        "coordinates": {
            "$ref": "#/definitions/position"
        },
        "crs": {
            "type": "string"
        }
    }
}
```