### PR TITLE
Fix view service properties in JSON extract

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -178,7 +178,7 @@ class Renderer(JsonRenderer):
         main_page_basemap = {
             'type': 'wms',
             'styles': 'default',
-            'opacity': extract_dict['RealEstate_PlanForLandRegisterMainPage'].get('LayerOpacity', 0.6),
+            'opacity': extract_dict['RealEstate_PlanForLandRegisterMainPage'].get('layerOpacity', 0.6),
             'baseURL': base_url,
             'layers': main_page_params['LAYERS'][0].split(','),
             'imageFormat': 'image/png',
@@ -189,7 +189,7 @@ class Renderer(JsonRenderer):
         basemap = {
             'type': 'wms',
             'styles': 'default',
-            'opacity': extract_dict['RealEstate_PlanForLandRegister'].get('LayerOpacity', 0.6),
+            'opacity': extract_dict['RealEstate_PlanForLandRegister'].get('layerOpacity', 0.6),
             'baseURL': urlparse.urlunsplit((url.scheme, url.netloc, url.path, None, None)),
             'layers': params['LAYERS'][0].split(','),
             'imageFormat': 'image/png',
@@ -220,7 +220,7 @@ class Renderer(JsonRenderer):
             restriction_on_landownership['baseLayers'] = {
                 'layers': [{
                     'type': 'wms',
-                    'opacity': restriction_on_landownership['Map'].get('LayerOpacity', 0.6),
+                    'opacity': restriction_on_landownership['Map'].get('layerOpacity', 0.6),
                     'styles': 'default',
                     'baseURL': urlparse.urlunsplit((url.scheme, url.netloc, url.path, None, None)),
                     'layers': params['LAYERS'][0].split(','),

--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -490,8 +490,8 @@ class Renderer(Base):
             map_dict['OtherLegend'] = [
                 self.format_legend_entry(legend_entry) for legend_entry in other_legend]
 
-        map_dict['LayerIndex'] = map_.layer_index
-        map_dict['LayerOpacity'] = map_.layer_opacity
+        map_dict['layerIndex'] = map_.layer_index
+        map_dict['layerOpacity'] = map_.layer_opacity
         if map_.min_NS03 is not None:
             map_dict['min_NS03'] = self.format_point(map_.min_NS03, 'EPSG:21781')
         if map_.max_NS03 is not None:

--- a/tests/contrib/print_proxy/resources/expected_getspec_extract.json
+++ b/tests/contrib/print_proxy/resources/expected_getspec_extract.json
@@ -773,7 +773,7 @@
   "PLRCadastreAuthority_PostalCode": 4410,
   "PLRCadastreAuthority_OfficeAtWeb": "http://www.agi.bl.ch",
   "RealEstate_PlanForLandRegisterMainPage": {
-    "LayerOpacity": 0.5,
+    "layerOpacity": 0.5,
     "ReferenceWMS": "http://dev2.geowms.bl.ch/?STYLES=default&LAYERS=grundbuchplan_gebaeude_nicht_gefuellt_group&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415"
   },
   "CantonalLogoRef": "http://dev2.geoview.bl.ch/vvmruder/oereb/image/logo/canton",

--- a/tests/contrib/print_proxy/resources/test_extract.json
+++ b/tests/contrib/print_proxy/resources/test_extract.json
@@ -382,11 +382,11 @@
     "Municipality": "Birsfelden",
     "PlanForLandRegister": {
       "ReferenceWMS": "http://dev2.geowms.bl.ch/?STYLES=default&LAYERS=grundbuchplan_gebaeude_nicht_gefuellt_group&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-      "LayerOpacity": 1
+      "layerOpacity": 1
     },
     "PlanForLandRegisterMainPage":  {
       "ReferenceWMS": "http://dev2.geowms.bl.ch/?STYLES=default&LAYERS=grundbuchplan_gebaeude_nicht_gefuellt_group&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-      "LayerOpacity": 0.5
+      "layerOpacity": 0.5
     },
     "Canton": "BL",
     "FosNr": 2766,
@@ -1092,7 +1092,7 @@
           ],
           "LegendAtWeb": "http://dev2.geoview.bl.ch/vvmruder/oereb/custom_legend_at_web/LandUsePlans.png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_nutzungsplanung_group&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "AreaShare": 78456.21,
         "ResponsibleOffice": {
@@ -1801,7 +1801,7 @@
           ],
           "LegendAtWeb": "http://dev2.geoview.bl.ch/vvmruder/oereb/custom_legend_at_web/LandUsePlans.png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_nutzungsplanung_group&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "AreaShare": 2681.31,
         "ResponsibleOffice": {
@@ -2510,7 +2510,7 @@
           ],
           "LegendAtWeb": "http://dev2.geoview.bl.ch/vvmruder/oereb/custom_legend_at_web/LandUsePlans.png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_nutzungsplanung_group&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "AreaShare": 6242.69,
         "ResponsibleOffice": {
@@ -3219,7 +3219,7 @@
           ],
           "LegendAtWeb": "http://dev2.geoview.bl.ch/vvmruder/oereb/custom_legend_at_web/LandUsePlans.png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_nutzungsplanung_group&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "AreaShare": 7379.93,
         "ResponsibleOffice": {
@@ -3928,7 +3928,7 @@
           ],
           "LegendAtWeb": "http://dev2.geoview.bl.ch/vvmruder/oereb/custom_legend_at_web/LandUsePlans.png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_nutzungsplanung_group&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "AreaShare": 6125.68,
         "ResponsibleOffice": {
@@ -4041,7 +4041,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_kataster_der_belasteten_standorte&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_kataster_der_belasteten_standorte&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {
@@ -4346,7 +4346,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_kataster_der_belasteten_standorte&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_kataster_der_belasteten_standorte&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {
@@ -4651,7 +4651,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_kataster_der_belasteten_standorte&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_kataster_der_belasteten_standorte&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {
@@ -4956,7 +4956,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_kataster_der_belasteten_standorte&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_kataster_der_belasteten_standorte&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {
@@ -5261,7 +5261,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_kataster_der_belasteten_standorte&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_kataster_der_belasteten_standorte&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {
@@ -5530,7 +5530,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_laermempfindlichkeitsstufen&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_laermempfindlichkeitsstufen&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {
@@ -5723,7 +5723,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_laermempfindlichkeitsstufen&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_laermempfindlichkeitsstufen&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {
@@ -5916,7 +5916,7 @@
           ],
           "LegendAtWeb": "http://dev2.geowms.bl.ch/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&LAYER=oereb_laermempfindlichkeitsstufen&FORMAT=image/png",
           "ReferenceWMS": "http://dev2.geowms.bl.ch/?LAYERS=oereb_laermempfindlichkeitsstufen&STYLES=default&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetMap&SRS=EPSG%3A2056&HEIGHT=280&WIDTH=493&VERSION=1.1.1&BBOX=2614423.83901%2C1266646.57585%2C2615979.16299%2C1267529.92415",
-          "LayerOpacity": 1
+          "layerOpacity": 1
         },
         "LegalProvisions": [
           {

--- a/tests/renderer/test_json.py
+++ b/tests/renderer/test_json.py
@@ -480,8 +480,8 @@ def test_format_map(config, params):
         assert isinstance(result, dict)
         assert result == {
             'Image': base64.b64encode('1'.encode('utf-8')).decode('ascii'),
-            'LayerIndex': 1,
-            'LayerOpacity': 1.0,
+            'layerIndex': 1,
+            'layerOpacity': 1.0,
             'ReferenceWMS': 'http://my.wms.ch',
             'LegendAtWeb': 'http://my.wms.ch?SERVICE=WMS&REQUEST=GetLegendGraphic',
             'OtherLegend': [renderer.format_legend_entry(legend_entry)]


### PR DESCRIPTION
According to [extractdata.json](http://schemas.geo.admin.ch/V_D/OeREB/1.0/extractdata.json), the properties `layerIndex` and `layerOpacity` should start with lower case letters.