### PR TITLE
Improve intersection

### DIFF
--- a/pyramid_oereb/lib/records/geometry.py
+++ b/pyramid_oereb/lib/records/geometry.py
@@ -103,8 +103,8 @@ class GeometryRecord(object):
                     self._test_passed = True
             else:
                 log.debug(
-                    'Intersection result changed geometry type. '
-                    'Original geometry was {0} and result is {1}'.format(
+                    u'Intersection result changed geometry type. '
+                    u'Original geometry was {0} and result is {1}'.format(
                         self.geom.type,
                         result.type
                     )

--- a/pyramid_oereb/lib/records/geometry.py
+++ b/pyramid_oereb/lib/records/geometry.py
@@ -72,21 +72,29 @@ class GeometryRecord(object):
         if self.published:
             result = self.geom.intersection(real_estate.limit)
             # differentiate between Points and MultiPoint
-            if result.type == point_types[1]:
-                # If it is a multipoint make a list and count the number of elements in the list
-                self._nr_of_points = len(list(result.geoms))
-                self._test_passed = True
-            elif result.type == point_types[0]:
-                # If it is a single point the number of points is one
-                self._nr_of_points = 1
-                self._test_passed = True
-            elif self.geom.type in line_types:
+            if self.geom.type not in point_types + line_types + polygon_types:
+                supported_types = ', '.join(point_types + line_types + polygon_types)
+                raise AttributeError(
+                    u'The passed geometry is not supported: {type}. It should be one of: {types}'.format(
+                        type=self.geom.type, types=supported_types
+                    )
+                )
+            if self.geom.type in point_types:
+                if result.type == point_types[1]:
+                    # If it is a multipoint make a list and count the number of elements in the list
+                    self._nr_of_points = len(list(result.geoms))
+                    self._test_passed = True
+                elif result.type == point_types[0]:
+                    # If it is a single point the number of points is one
+                    self._nr_of_points = 1
+                    self._test_passed = True
+            elif self.geom.type in line_types and result.type in line_types:
                 self._units = length_unit
                 length_share = result.length
                 if length_share >= min_length:
                     self._length_share = length_share
                     self._test_passed = True
-            elif self.geom.type in polygon_types:
+            elif self.geom.type in polygon_types and result.type in polygon_types:
                 self._units = area_unit
                 area_share = result.area
                 compensated_area = area_share / real_estate.areas_ratio
@@ -94,10 +102,13 @@ class GeometryRecord(object):
                     self._area_share = compensated_area
                     self._test_passed = True
             else:
-                supported_types = ', '.join(point_types + line_types + polygon_types)
-                raise AttributeError(
-                    u'The passed geometry is not supported: {type}. It should be one of: {types}'
-                    .format(type=self.geom.type, types=supported_types))
+                log.debug(
+                    'Intersection result changed geometry type. '
+                    'Original geometry was {0} and result is {1}'.format(
+                        self.geom.type,
+                        result.type
+                    )
+                )
         self.calculated = True
         return self._test_passed
 

--- a/tests/records/test_geometry.py
+++ b/tests/records/test_geometry.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, MultiPolygon
 
 import pytest
 
 from pyramid_oereb.lib.records.geometry import GeometryRecord
+from pyramid_oereb.lib.records.law_status import LawStatusRecord
+from pyramid_oereb.lib.records.real_estate import RealEstateRecord
 
 
 def test_mandatory_fields():
@@ -21,3 +23,35 @@ def test_init():
     assert isinstance(record.geom, Polygon)
     assert record.public_law_restriction is None
     assert record.office is None
+
+
+def test_calculate():
+    law_status_record = LawStatusRecord("runningModifications", {u'de': u'BlaBla'})
+    geometry_record = GeometryRecord(
+        law_status_record,
+        datetime.date(1985, 8, 29),
+        Polygon(((0, 0), (0, 1), (1, 1), (1, 0))),
+        'test'
+    )
+
+    real_estate = RealEstateRecord(
+        'Liegenschaft',
+        'BL',
+        'Aesch BL',
+        2761,
+        100,
+        MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))])
+    )
+    geometry_record.calculate(real_estate, 1, 1, 'm', 'm2')
+    assert geometry_record._test_passed
+
+    real_estate = RealEstateRecord(
+        'Liegenschaft',
+        'BL',
+        'Aesch BL',
+        2761,
+        100,
+        MultiPolygon([Polygon(((1, 1), (1, 2), (2, 2), (2, 1)))])
+    )
+    geometry_record.calculate(real_estate, 1, 1, 'm', 'm2')
+    assert not geometry_record._test_passed

--- a/tests/records/test_geometry.py
+++ b/tests/records/test_geometry.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-from shapely.geometry import Polygon, MultiPolygon
+import math
+
+from shapely.geometry import Polygon, MultiPolygon, LineString, Point, MultiPoint
 
 import pytest
 
@@ -25,33 +27,140 @@ def test_init():
     assert record.office is None
 
 
-def test_calculate():
+@pytest.mark.parametrize(
+    "geometry,real_estate_geometry,length_limit,area_limit,length_share,area_share,nr_of_points,test", [
+        (
+            # Intersection area with area result: Polygon in limit, should pass
+            Polygon(((0, 0), (0, 1), (1, 1), (1, 0))),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            1,
+            None,
+            1,
+            None,
+            True
+        ), (
+            # Intersection area with area result: Polygon not in limit, should be dismissed
+            Polygon(((0, 0), (0, 1), (1, 1), (1, 0))),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            2,
+            None,
+            None,
+            None,
+            False
+        ), (
+            # Intersection area with area result: Point, should be dismissed
+            Polygon(((0, 0), (0, 1), (1, 1), (1, 0))),
+            MultiPolygon([Polygon(((1, 1), (1, 2), (2, 2), (2, 1)))]),
+            1,
+            1,
+            None,
+            None,
+            None,
+            False
+        ), (
+            # Intersection area with area result: Line, should be dismissed
+            Polygon(((0, 0), (0, 1), (1, 1), (1, 0))),
+            MultiPolygon([Polygon(((1, 1), (2, 1), (2, 0), (1, 0)))]),
+            1,
+            1,
+            None,
+            None,
+            None,
+            False
+        ), (
+            # Intersection area with line result: Line in limit, should pass
+            LineString(((0, 0), (1, 1))),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            1,
+            math.sqrt(2),
+            None,
+            None,
+            True
+        ), (
+            # Intersection area with line result: Line not in limit, should be dismissed
+            LineString(((0, 0), (1, 1))),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            2,
+            1,
+            None,
+            None,
+            None,
+            False
+        ), (
+            # Intersection area with line result: Line on border of area, should pass
+            LineString(((0, 0), (0, 1))),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            1,
+            1,
+            None,
+            None,
+            True
+        ), (
+            # Intersection area with line result: Point, should be dismissed
+            LineString(((1, 1), (2, 2))),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            1,
+            None,
+            None,
+            None,
+            False
+        ), (
+            # Intersection area with point result: Point, should pass
+            Point((0.5, 0.5)),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            1,
+            None,
+            None,
+            1,
+            True
+        ), (
+            # Intersection area with point result: Point, should be dismissed
+            Point((2, 2)),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            1,
+            None,
+            None,
+            None,
+            False
+        ), (
+            # Intersection area with point result: Point, should pass
+            MultiPoint([Point((0.4, 0.4)), Point((0.5, 0.5)), Point((0.6, 0.6))]),
+            MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]),
+            1,
+            1,
+            None,
+            None,
+            3,
+            True
+        )
+    ]
+)
+def test_calculate(geometry, real_estate_geometry, length_limit, area_limit, length_share, area_share,
+                   nr_of_points, test):
     law_status_record = LawStatusRecord("runningModifications", {u'de': u'BlaBla'})
     geometry_record = GeometryRecord(
         law_status_record,
         datetime.date(1985, 8, 29),
-        Polygon(((0, 0), (0, 1), (1, 1), (1, 0))),
+        geometry,
         'test'
     )
-
     real_estate = RealEstateRecord(
         'Liegenschaft',
         'BL',
         'Aesch BL',
         2761,
-        100,
-        MultiPolygon([Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))])
+        1,
+        real_estate_geometry
     )
-    geometry_record.calculate(real_estate, 1, 1, 'm', 'm2')
-    assert geometry_record._test_passed
-
-    real_estate = RealEstateRecord(
-        'Liegenschaft',
-        'BL',
-        'Aesch BL',
-        2761,
-        100,
-        MultiPolygon([Polygon(((1, 1), (1, 2), (2, 2), (2, 1)))])
-    )
-    geometry_record.calculate(real_estate, 1, 1, 'm', 'm2')
-    assert not geometry_record._test_passed
+    geometry_record.calculate(real_estate, length_limit, area_limit, 'm', 'm2')
+    assert geometry_record._test_passed == test
+    assert geometry_record._length_share == length_share
+    assert geometry_record._area_share == area_share
+    assert geometry_record._nr_of_points == nr_of_points


### PR DESCRIPTION
We encountered a strange behaviour when a area was intersected with the real estate and the result was a point. Then pyramid_oereb delivered a point. This is obviously incorrect.

As far as I think this should solve the problem. Of course we do not want to have changed geometries.