### PR TITLE
Add type casts in availability check

### DIFF
--- a/pyramid_oereb/standard/sources/plr.py
+++ b/pyramid_oereb/standard/sources/plr.py
@@ -548,6 +548,6 @@ class DatabaseSource(BaseDatabaseSource, PlrBaseSource):
              bool: True if the topic is available, false otherwise.
         """
         for availability in self.availabilities:
-            if real_estate.fosnr == availability.fosnr and not availability.available:
+            if int(real_estate.fosnr) == int(availability.fosnr) and not availability.available:
                 return False
         return True


### PR DESCRIPTION
Add integer type casts for the attribute `fosnr` as it might be defined as `character varying` ("primary key as string" option in `create_standard_model` script).