### PR TITLE
Optional referer for GeoAdmin Search API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install: $(PYTHON_VENV)
 	touch $@
 
 $(SPHINXBUILD): .venv/requirements-timestamp
-	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install Sphinx<1.8 sphinxcontrib-napoleon sphinx_rtd_theme
+	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install "Sphinx<1.8" sphinxcontrib-napoleon sphinx_rtd_theme
 
 .PHONY: doc
 doc: $(SPHINXBUILD)

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install: $(PYTHON_VENV)
 	touch $@
 
 $(SPHINXBUILD): .venv/requirements-timestamp
-	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install Sphinx sphinxcontrib-napoleon sphinx_rtd_theme
+	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install Sphinx<1.8 sphinxcontrib-napoleon sphinx_rtd_theme
 
 .PHONY: doc
 doc: $(SPHINXBUILD)

--- a/pyramid_oereb/contrib/sources/address.py
+++ b/pyramid_oereb/contrib/sources/address.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import requests
 from pyreproj import Reprojector
+from shapely.geometry import Point
 
 from pyramid_oereb import Config
-from pyramid.config import ConfigurationError
 from pyramid_oereb.lib.records.address import AddressRecord
 from pyramid_oereb.lib.sources.address import AddressBaseSource
 
@@ -29,8 +29,6 @@ class AddressGeoAdminSource(AddressBaseSource):
         self._type = 'locations'
         self._proxies = kwargs.get('proxies')
         self._referer = kwargs.get('referer', None)
-        if self._referer is None:
-            raise ConfigurationError('A referer must be set to use GeoAdmin service as source for address.')
         if 'origins' in kwargs:
             origins = kwargs.get('origins')
             if isinstance(origins, list):
@@ -48,9 +46,11 @@ class AddressGeoAdminSource(AddressBaseSource):
             zip_code (int): The postal zipcode for the desired address.
             street_number (unicode): The house or so called street number of the desired address.
         """
-        headers = {
-            'Referer': self._referer
-        }
+        headers = {}
+        if self._referer is not None:
+            headers.update({
+                'Referer': self._referer
+            })
         params = {
             'type': self._type,
             'origins': self._origins,
@@ -71,7 +71,7 @@ class AddressGeoAdminSource(AddressBaseSource):
                             street_name=street_name,
                             zip_code=zip_code,
                             street_number=street_number,
-                            geom='POINT({x} {y})'.format(x=x, y=y)
+                            geom=Point(x, y)
                         ))
         else:
             response.raise_for_status()

--- a/pyramid_oereb/contrib/sources/address.py
+++ b/pyramid_oereb/contrib/sources/address.py
@@ -19,7 +19,7 @@ class AddressGeoAdminSource(AddressBaseSource):
         Keyword Args:
             geoadmin_search_api (uri): Url of the GeoAdmin API's search service. (**required**)
             origins (str or list of str): Filter results by origin. Defaults to *address*. (**optional**)
-            referer (str): Referer to use.
+            referer (str): Referer to use. (**optional**)
             proxies (dict): Proxy definition according to
                 http://docs.python-requests.org/en/master/user/advanced/#proxies. (**optional**)
         """

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -260,8 +260,8 @@ pyramid_oereb:
         # Alternatively, you can use the search service of the GeoAdmin API to look up the real estate by
         # address. Replace the configuration above with the following lines:
         # class: pyramid_oereb.lib.sources.address.AddressGeoAdminSource
-        # # The referer to use.
-        # referer: http://canton.ch
+        # # Optional referer to use.
+        # referer: http://my.referer.ch
         # params:
           # # URL of the GeoAdmin API SearchServer
           # geoadmin_search_api: https://api3.geo.admin.ch/rest/services/api/SearchServer

--- a/pyramid_oereb/standard/sources/address.py
+++ b/pyramid_oereb/standard/sources/address.py
@@ -37,7 +37,7 @@ class DatabaseSource(BaseDatabaseSource, AddressBaseSource):
                     result.street_name,
                     result.zip_code,
                     result.street_number,
-                    to_shape(result.geom).wkt if isinstance(result.geom, _SpatialElement) else None
+                    to_shape(result.geom) if isinstance(result.geom, _SpatialElement) else None
                 ))
 
         except NoResultFound:

--- a/pyramid_oereb/views/webservice.py
+++ b/pyramid_oereb/views/webservice.py
@@ -180,7 +180,7 @@ class PlrWebservice(object):
             addresses = reader.read(localisation, int(postalcode), number)
             if len(addresses) == 0:
                 return HTTPNoContent()
-            geometry = 'SRID={srid};{wkt}'.format(srid=Config.get('srid'), wkt=addresses[0].geom)
+            geometry = 'SRID={srid};{wkt}'.format(srid=Config.get('srid'), wkt=addresses[0].geom.wkt)
             records = self._real_estate_reader.read(**{'geometry': geometry})
             return self.__get_egrid_response__(records)
         else:

--- a/tests/sources/test_address_geoadmin.py
+++ b/tests/sources/test_address_geoadmin.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 import requests_mock
 from requests import HTTPError
+from shapely.geometry import Point
 
 from pyramid_oereb.lib.records.address import AddressRecord
 from pyramid_oereb.contrib.sources.address import AddressGeoAdminSource
@@ -86,7 +87,6 @@ def test_read(status_code, config):
             assert address.street_number == u'36'
             assert address.zip_code == 4410
             assert address.street_name == u'Muehlemattstrasse'
-            if sys.version_info.major == 2:
-                assert address.geom == 'POINT(2621857.987 1259852.8231)'
-            else:
-                assert address.geom == 'POINT(2621857.9869956686 1259852.8231037352)'
+            assert isinstance(address.geom, Point)
+            assert address.geom.x == 2621857.9869956686
+            assert address.geom.y == 1259852.8231037352

--- a/tests/sources/test_address_geoadmin.py
+++ b/tests/sources/test_address_geoadmin.py
@@ -14,24 +14,24 @@ else:
 
 
 @pytest.mark.parametrize('i, cfg', [
-    (1, {'referer': 'http://bl.ch'}),
-    (2, {'referer': 'http://bl.ch', 'geoadmin_search_api': 'http://my.api.com', 'origins': 'test'}),
-    (3, {'referer': 'http://bl.ch', 'geoadmin_search_api': 'http://my.api.com',
+    (1, {}),
+    (2, {'referer': 'http://ref.ch', 'geoadmin_search_api': 'http://my.api.com', 'origins': 'test'}),
+    (3, {'referer': 'http://ref.ch', 'geoadmin_search_api': 'http://my.api.com',
          'origins': ['test1', 'test2']})
 ])
 def test_init(i, cfg):
     source = AddressGeoAdminSource(**cfg)
     assert isinstance(source, AddressGeoAdminSource)
     if i == 1:
-        assert source._referer == 'http://bl.ch'
+        assert source._referer is None
         assert source._geoadmin_url == 'https://api3.geo.admin.ch/rest/services/api/SearchServer'
         assert source._origins == 'address'
     elif i == 2:
-        assert source._referer == 'http://bl.ch'
+        assert source._referer == 'http://ref.ch'
         assert source._geoadmin_url == 'http://my.api.com'
         assert source._origins == 'test'
     elif i == 3:
-        assert source._referer == 'http://bl.ch'
+        assert source._referer == 'http://ref.ch'
         assert source._geoadmin_url == 'http://my.api.com'
         assert source._origins == 'test1,test2'
 
@@ -64,8 +64,7 @@ def test_read(status_code, config):
         ]
     }
     source = AddressGeoAdminSource(
-            geoadmin_search_api=u'http://my.api.com/addresses',
-            referer='http://bl.ch')
+            geoadmin_search_api=u'http://my.api.com/addresses')
     zip_code = 4410
     street_name = u'Muehlemattstrasse'
     street_number = u'36'


### PR DESCRIPTION
The referer for the GeoAdmin Search API isn't mandatory anymore. The `ConfigurationError` on missing referer can be removed.

Additionally, the address geometry should be stored as shapely `Point` instead of WKT according to the documentation.