### PR TITLE
Improve PDF layout

### DIFF
--- a/print/print-apps/oereb/legalprovision.jrxml
+++ b/print/print-apps/oereb/legalprovision.jrxml
@@ -28,14 +28,18 @@
 	<field name="OfficialTitle" class="java.lang.String"/>
 	<field name="Abbreviation" class="java.lang.String"/>
 	<detail>
-		<band height="40">
+		<band height="25">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<printWhenExpression><![CDATA[$F{Title} != null || $F{OfficialTitle} != null]]></printWhenExpression>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
-				<reportElement positionType="Float" x="0" y="15" width="300" height="15" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				<reportElement positionType="Float" x="0" y="13" width="300" height="12" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="local_mesure_unity" value="pixel"/>
 					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
-				<box topPadding="1"/>
+				<box topPadding="0" bottomPadding="3"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
 					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
@@ -44,20 +48,45 @@
 				<hyperlinkReferenceExpression><![CDATA[($F{TextAtWeb}.equals("") || $F{TextAtWeb} == null) ? null : $F{TextAtWeb}]]></hyperlinkReferenceExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
-				<reportElement x="190" y="0" width="110" height="15" uuid="179b7611-a023-4e6c-bd26-1f128b45058d"/>
+				<reportElement x="190" y="0" width="110" height="10" uuid="179b7611-a023-4e6c-bd26-1f128b45058d">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
 				<textFieldExpression><![CDATA[((ArrayList)$P{TOC_Appendices}.get($P{Theme_Text})).add($F{Title}.equals("") ? $F{OfficialTitle} : $F{Title}) ? "" : ""]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" bookmarkLevel="2">
-				<reportElement x="0" y="0" width="300" height="15" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				<reportElement x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="local_mesure_unity" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
 				</reportElement>
+				<box bottomPadding="3"/>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Cadastra" size="8"/>
 					<paragraph lineSpacing="Single"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($F{Title}.equals("") ? ($F{OfficialTitle}.equals("") ? "-" :   $F{OfficialTitle}): $F{Title}) + (($F{Abbreviation}.equals("") || $F{Abbreviation} == null) ? "" : " (" + $F{Abbreviation} + ")") + (($F{OfficialNumber}.equals("") || $F{OfficialNumber} == null) ? "" : ", " + $F{OfficialNumber})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[($F{Title}.equals("") || $F{Title} == null ? ($F{OfficialTitle}.equals("") || $F{OfficialTitle} == null ? "-" :   $F{OfficialTitle}): $F{Title}) + (($F{Abbreviation}.equals("") || $F{Abbreviation} == null) ? "" : " (" + $F{Abbreviation} + ")") + (($F{OfficialNumber}.equals("") || $F{OfficialNumber} == null) ? "" : ", " + $F{OfficialNumber})]]></textFieldExpression>
 			</textField>
+		</band>
+		<band height="13">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<printWhenExpression><![CDATA[$F{Title} == null && $F{OfficialTitle} == null]]></printWhenExpression>
+			<staticText>
+				<reportElement x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" uuid="54a11828-13b7-448c-a1ee-27dfaeb28bd0">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<box bottomPadding="3"/>
+				<textElement markup="html"/>
+				<text><![CDATA[&mdash;]]></text>
+			</staticText>
 		</band>
 	</detail>
 </jasperReport>

--- a/print/print-apps/oereb/toc.jrxml
+++ b/print/print-apps/oereb/toc.jrxml
@@ -312,7 +312,7 @@
 		</band>
 		<band height="30">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-			<textField isBlankWhenNull="true">
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement x="0" y="15" width="230" height="10" isPrintWhenDetailOverflows="true" uuid="a362c07e-fbe0-4a89-917b-bb72fa58f73c">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>

--- a/print/print-apps/oereb/topicpage.jrxml
+++ b/print/print-apps/oereb/topicpage.jrxml
@@ -207,8 +207,6 @@
 				<reportElement positionType="FixRelativeToBottom" x="445" y="375" width="48" height="10" uuid="c75cc18b-c481-4a35-877e-1c17e88901b1">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="mm"/>
-					<printWhenExpression><![CDATA[!"NrOfPoints".equals($F{Geom_Type}) && !"LengthShare".equals($F{Geom_Type})]]></printWhenExpression>
 				</reportElement>
 				<textElement textAlignment="Right" verticalAlignment="Middle">
 					<font fontName="Cadastra" size="6.5"/>
@@ -261,14 +259,18 @@
 				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
 			</subreport>
 		</band>
-		<band height="17">
+		<band height="19">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<textField isStretchWithOverflow="true">
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="493" height="17" isPrintWhenDetailOverflows="true" uuid="8ef5ca32-4156-4f98-ba33-972d48815976">
+				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="493" height="19" isPrintWhenDetailOverflows="true" uuid="8ef5ca32-4156-4f98-ba33-972d48815976">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>
-				<box>
+				<box topPadding="3">
 					<topPen lineWidth="0.2"/>
 				</box>
 				<textElement>
@@ -277,8 +279,11 @@
 				<textFieldExpression><![CDATA[$R{LegendLabel}]]></textFieldExpression>
 			</textField>
 			<subreport>
-				<reportElement stretchType="RelativeToTallestObject" x="193" y="0" width="299" height="17" isRemoveLineWhenBlank="true" uuid="887d710f-c4a0-4c31-b96d-65b98a6ce66b">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				<reportElement stretchType="RelativeToTallestObject" x="193" y="3" width="299" height="16" isRemoveLineWhenBlank="true" uuid="887d710f-c4a0-4c31-b96d-65b98a6ce66b">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<subreportParameter name="Geom_Type">
 					<subreportParameterExpression><![CDATA[$F{Geom_Type}]]></subreportParameterExpression>
@@ -287,22 +292,28 @@
 				<subreportExpression><![CDATA["topiclegend.jasper"]]></subreportExpression>
 			</subreport>
 		</band>
-		<band height="24">
+		<band height="19">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<subreport>
-				<reportElement stretchType="RelativeToTallestObject" mode="Transparent" x="193" y="0" width="299" height="17" isRemoveLineWhenBlank="true" uuid="f88a6ee0-42e5-4d2c-b1ab-9abb4f950664">
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+				<reportElement stretchType="RelativeToTallestObject" mode="Transparent" x="193" y="3" width="299" height="16" isRemoveLineWhenBlank="true" uuid="f88a6ee0-42e5-4d2c-b1ab-9abb4f950664">
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
 				</reportElement>
 				<dataSourceExpression><![CDATA[$F{OtherLegendDataSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["topicotherlegend.jasper"]]></subreportExpression>
 			</subreport>
 			<textField isBlankWhenNull="false">
-				<reportElement x="0" y="0" width="493" height="24" uuid="c7bafe02-64a5-407f-b511-dde165687582">
+				<reportElement x="0" y="0" width="493" height="19" uuid="c7bafe02-64a5-407f-b511-dde165687582">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
 				</reportElement>
-				<box>
+				<box topPadding="3">
 					<topPen lineWidth="0.2" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<bottomPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -324,7 +335,7 @@
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
-				<box>
+				<box topPadding="3">
 					<topPen lineWidth="0.2"/>
 				</box>
 				<textElement>
@@ -333,11 +344,13 @@
 				<textFieldExpression><![CDATA[$R{CompleteLegendLabel}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
-				<reportElement stretchType="RelativeToTallestObject" mode="Transparent" x="193" y="0" width="300" height="17" forecolor="#4C8FBA" uuid="a70d3e5c-bc32-4737-ba76-60f6cc56a8e2">
+				<reportElement stretchType="RelativeToTallestObject" mode="Transparent" x="193" y="0" width="300" height="19" forecolor="#4C8FBA" uuid="a70d3e5c-bc32-4737-ba76-60f6cc56a8e2">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
 				</reportElement>
+				<box topPadding="3" bottomPadding="3"/>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
 					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
@@ -348,9 +361,12 @@
 		</band>
 		<band height="19">
 			<subreport>
-				<reportElement mode="Transparent" x="193" y="0" width="300" height="17" isRemoveLineWhenBlank="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
+				<reportElement mode="Transparent" x="193" y="3" width="300" height="16" isRemoveLineWhenBlank="true" uuid="aea2a6e2-1814-4099-b8e4-6e588177db99">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<subreportParameter name="TOC_Appendices">
 					<subreportParameterExpression><![CDATA[$P{TOC_Appendices}]]></subreportParameterExpression>
@@ -364,9 +380,12 @@
 			<textField>
 				<reportElement x="0" y="0" width="493" height="19" uuid="bc365be9-27bf-41cb-8f51-82a3b7af3eda">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
 				</reportElement>
-				<box>
+				<box topPadding="3">
 					<topPen lineWidth="0.2"/>
 				</box>
 				<textElement>
@@ -375,10 +394,16 @@
 				<textFieldExpression><![CDATA[$R{LegalProvisionLabel}]]></textFieldExpression>
 			</textField>
 		</band>
-		<band height="30">
+		<band height="19">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<subreport>
-				<reportElement mode="Transparent" x="193" y="0" width="300" height="30" isRemoveLineWhenBlank="true" uuid="1d3ac1d8-7b5e-4caa-bcc0-cf857dddc651">
+				<reportElement mode="Transparent" x="193" y="3" width="300" height="16" isRemoveLineWhenBlank="true" uuid="1d3ac1d8-7b5e-4caa-bcc0-cf857dddc651">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<subreportParameter name="TOC_Appendices">
 					<subreportParameterExpression><![CDATA[$P{TOC_Appendices}]]></subreportParameterExpression>
@@ -393,8 +418,12 @@
 				<reportElement x="0" y="0" width="493" height="19" uuid="8f553e43-b8da-410e-b472-0116a8793b6d">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
-				<box>
+				<box topPadding="3">
 					<topPen lineWidth="0.2"/>
 				</box>
 				<textElement>
@@ -403,10 +432,16 @@
 				<textFieldExpression><![CDATA[$R{LegalBasesLabel}]]></textFieldExpression>
 			</textField>
 		</band>
-		<band height="30">
+		<band height="19">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<subreport>
-				<reportElement mode="Transparent" x="193" y="0" width="300" height="30" isRemoveLineWhenBlank="true" uuid="1d3ac1d8-7b5e-4caa-bcc0-cf857dddc651">
+				<reportElement mode="Transparent" x="193" y="3" width="300" height="16" isRemoveLineWhenBlank="true" backcolor="#FFFFFF" uuid="1d3ac1d8-7b5e-4caa-bcc0-cf857dddc651">
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<subreportParameter name="TOC_Appendices">
 					<subreportParameterExpression><![CDATA[$P{TOC_Appendices}]]></subreportParameterExpression>
@@ -418,12 +453,15 @@
 				<subreportExpression><![CDATA["legalprovision.jasper"]]></subreportExpression>
 			</subreport>
 			<textField>
-				<reportElement x="0" y="0" width="493" height="24" uuid="94ac5c43-32f0-4769-ba84-96a56cb660b6">
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
+				<reportElement x="0" y="0" width="493" height="19" uuid="94ac5c43-32f0-4769-ba84-96a56cb660b6">
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+					<property name="local_mesure_unity" value="pixel"/>
 				</reportElement>
-				<box>
+				<box topPadding="3">
 					<topPen lineWidth="0.2"/>
 				</box>
 				<textElement>


### PR DESCRIPTION
- Dont't cut off cadastral surveying date on TOC page
- Always show title for "part in %" (due to specification)
- Adjust padding around legal documents