### PR TITLE
Fix namespace in capabilities XML template

### DIFF
--- a/pyramid_oereb/lib/renderer/capabilities/templates/xml/capabilities.xml
+++ b/pyramid_oereb/lib/renderer/capabilities/templates/xml/capabilities.xml
@@ -3,15 +3,16 @@
 <GetCapabilitiesResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                          xmlns="http://schemas.geo.admin.ch/V_D/OeREB/1.0/Extract"
-                         xsi:schemaLocation="http://schemas.geo.admin.ch/V_D/OeREB/1.0/Extract http://schemas.geo.admin.ch/V_D/OeREB/1.0/Extract.xsd">
+                         xmlns:data="http://schemas.geo.admin.ch/V_D/OeREB/1.0/ExtractData"
+                         xsi:schemaLocation="http://schemas.geo.admin.ch/V_D/OeREB/1.0/Extract http://schemas.geo.admin.ch/V_D/OeREB/1.0/Extract.xsd http://schemas.geo.admin.ch/V_D/OeREB/1.0/ExtractData http://schemas.geo.admin.ch/V_D/OeREB/1.0/ExtractData.xsd">
     % for item in data['GetCapabilitiesResponse']['topic']:
     <topic>
-        <Code>${item['Code']}</Code>
+        <data:Code>${item['Code']}</data:Code>
         % for ltext in item['Text']:
-        <Text>
-            <Language>${ltext['Language']}</Language>
-            <Text>${ltext['Text']}</Text>
-        </Text>
+        <data:Text>
+            <data:Language>${ltext['Language']}</data:Language>
+            <data:Text>${ltext['Text']}</data:Text>
+        </data:Text>
         % endfor
     </topic>
     % endfor


### PR DESCRIPTION
The validation of the capabilities response fails because of the missing namespace for `ExtractData`.