### PR TITLE
fix doc image inclusion

### DIFF
--- a/doc/source/standard/models/index.rst.mako
+++ b/doc/source/standard/models/index.rst.mako
@@ -9,7 +9,7 @@ Models
 Exemplary schema of a standard database
 ---------------------------------------
 
-.. image:: ../images/standard_database_schema_example.png
+.. image:: ../../../images/standard_database_schema_example.png
    :scale: 20 %
    :align: center
 


### PR DESCRIPTION
"make doc" currently fails
(this is the reason for the general status red of Travis CI - a PRs CI does not do make doc, so we did not notice this with the PR that first added the new doc image, but the CI upon merge into master does do a make doc... and fails with a seemingly unrelated sphinx message)