### PR TITLE
revert to older Sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_success:
 - git clean -x
 
 before_deploy:
-- pip install sphinxcontrib-versioning 'Sphinx<1.8' Mako sphinx_rtd_theme sphinxcontrib.napoleon --editable .[recommend]
+- pip install sphinxcontrib-versioning 'Sphinx<1.6' Mako sphinx_rtd_theme --editable .[recommend]
 - openssl aes-256-cbc -K $encrypted_43de73a10f25_key -iv $encrypted_43de73a10f25_iv -in deploy_rsa.enc -out ~/.ssh/id_rsa -d
 - eval "$(ssh-agent -s)"
 - chmod 0600 ~/.ssh/id_rsa

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install: $(PYTHON_VENV)
 	touch $@
 
 $(SPHINXBUILD): .venv/requirements-timestamp
-	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install "Sphinx<1.8" sphinx_rtd_theme
+	$(VENV_BIN)pip$(PYTHON_BIN_POSTFIX) install "Sphinx<1.6" sphinx_rtd_theme
 
 .PHONY: doc
 doc: $(SPHINXBUILD)


### PR DESCRIPTION
revert to older Sphinx, as work-around for https://github.com/Robpol86/sphinxcontrib-versioning/issues/39. Furthermore, remove external napoleon in travis, to be consistent with project Makefile