### PR TITLE
fixed list of keys for python 3

### DIFF
--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -231,7 +231,7 @@ class Renderer(JsonRenderer):
                 self._multilingual_text(legend_item, 'LegendText')
 
             for legend_entry in restriction_on_landownership['OtherLegend']:
-                for element in legend_entry.keys():
+                for element in list(legend_entry.keys()):
                     if element not in ['LegendText', 'SymbolRef', 'TypeCode']:
                         del legend_entry[element]
 


### PR DESCRIPTION
Fixes issue: https://github.com/camptocamp/pyramid_oereb/issues/695

The cleanup of the OtherLegend elements iteration throws an error with python 3 and aborts the PDF extract creation. 
