### PR TITLE
Subthemes in print templates

### DIFF
--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -86,6 +86,9 @@ vars:
       # Whether to display the RealEstate_SubunitOfLandRegister (Grundbuchkreis) in the pdf extract or not.
       # Default to true.
       display_real_estate_subunit_of_land_register: true
+      # Split themes up, so that each sub theme gets its own page
+      # Disabled by default.
+      split_sub_themes: false
 
     # The "app_schema" property contains only one sub property "name". This is directly related to the database
     # creation process. Because this name is used as schema name in the target database. The app_schema holds

--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -106,8 +106,8 @@ templates:
                         default: ''
                     SubTheme: !string
                         default: ''
-                    SubTheme_Text: !string
-                        default: ''
+                    Split_SubTheme: !boolean
+                        default: false
                     Lawstatus_Code: *optStr
                     Lawstatus_Text: *optStr #/definitions/LocalisedText
                     Symbol: !string

--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -106,6 +106,8 @@ templates:
                         default: ''
                     SubTheme: !string
                         default: ''
+                    SubTheme_Text: !string
+                        default: ''
                     Lawstatus_Code: *optStr
                     Lawstatus_Text: *optStr #/definitions/LocalisedText
                     Symbol: !string

--- a/print/print-apps/oereb/topicpage.jrxml
+++ b/print/print-apps/oereb/topicpage.jrxml
@@ -79,7 +79,8 @@
 	<parameter name="TOC_Appendices" class="java.util.Map"/>
 	<field name="mapSubReport" class="java.lang.String"/>
 	<field name="Theme_Text" class="java.lang.String"/>
-	<field name="SubTheme_Text" class="java.lang.String"/>
+	<field name="SubTheme" class="java.lang.String"/>
+	<field name="Split_SubTheme" class="java.lang.Boolean"/>
 	<field name="Geom_Type" class="java.lang.String"/>
 	<field name="legend" class="java.lang.String"/>
 	<field name="ResponsibleOffice_Name" class="java.lang.String"/>
@@ -178,7 +179,7 @@
 					<font size="16" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{Theme_Text}]]></textFieldExpression>
-				<anchorNameExpression><![CDATA[($F{SubTheme_Text}.equals("") || $F{SubTheme_Text} == null) ? $F{Theme_Text} : ($F{Theme_Text} + ": " + $F{SubTheme_Text})]]></anchorNameExpression>
+				<anchorNameExpression><![CDATA[$F{Split_SubTheme} ? ($F{Theme_Text} + ": " + $F{SubTheme}) : $F{Theme_Text}]]></anchorNameExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
 				<reportElement x="0" y="50" width="493" height="18" isRemoveLineWhenBlank="true" uuid="22c80cf5-78d8-4791-9eb9-ac621df1a041">
@@ -189,7 +190,7 @@
 				<textElement>
 					<font size="14" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{SubTheme_Text}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{Split_SubTheme} ? $F{SubTheme} : null]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="0" y="50" width="492" height="20" uuid="60969764-be9a-421d-bdd8-9b46e410d1f8"/>

--- a/print/print-apps/oereb/topicpage.jrxml
+++ b/print/print-apps/oereb/topicpage.jrxml
@@ -79,6 +79,7 @@
 	<parameter name="TOC_Appendices" class="java.util.Map"/>
 	<field name="mapSubReport" class="java.lang.String"/>
 	<field name="Theme_Text" class="java.lang.String"/>
+	<field name="SubTheme_Text" class="java.lang.String"/>
 	<field name="Geom_Type" class="java.lang.String"/>
 	<field name="legend" class="java.lang.String"/>
 	<field name="ResponsibleOffice_Name" class="java.lang.String"/>
@@ -177,7 +178,18 @@
 					<font size="16" isBold="true"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{Theme_Text}]]></textFieldExpression>
-				<anchorNameExpression><![CDATA[$F{Theme_Text}]]></anchorNameExpression>
+				<anchorNameExpression><![CDATA[($F{SubTheme_Text}.equals("") || $F{SubTheme_Text} == null) ? $F{Theme_Text} : ($F{Theme_Text} + ": " + $F{SubTheme_Text})]]></anchorNameExpression>
+			</textField>
+			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
+				<reportElement x="0" y="50" width="493" height="18" isRemoveLineWhenBlank="true" uuid="22c80cf5-78d8-4791-9eb9-ac621df1a041">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="mm"/>
+				</reportElement>
+				<textElement>
+					<font size="14" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{SubTheme_Text}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="0" y="50" width="492" height="20" uuid="60969764-be9a-421d-bdd8-9b46e410d1f8"/>

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -282,6 +282,13 @@ class Renderer(JsonRenderer):
         ]
         for restriction_on_landownership in extract_dict.get('RealEstate_RestrictionOnLandownership', []):
             theme = restriction_on_landownership['Theme_Code']
+
+            split_sub_themes = Config.get('print', {}).get('split_sub_themes', False)
+            if split_sub_themes:
+                if 'SubTheme' in restriction_on_landownership:
+                    theme = theme + '_' + restriction_on_landownership['SubTheme']
+                    restriction_on_landownership['SubTheme_Text'] = restriction_on_landownership['SubTheme']
+
             geom_type = \
                 'AreaShare' if 'AreaShare' in restriction_on_landownership else \
                 'LengthShare' if 'LengthShare' in restriction_on_landownership else 'NrOfPoints'

--- a/pyramid_oereb/contrib/print_proxy/mapfish_print.py
+++ b/pyramid_oereb/contrib/print_proxy/mapfish_print.py
@@ -280,14 +280,14 @@ class Renderer(JsonRenderer):
             'TypeCode', 'TypeCodelist', 'AreaShare', 'PartInPercent', 'LengthShare',
             'SymbolRef', 'Information'
         ]
+        split_sub_themes = Config.get('print', {}).get('split_sub_themes', False)
         for restriction_on_landownership in extract_dict.get('RealEstate_RestrictionOnLandownership', []):
             theme = restriction_on_landownership['Theme_Code']
 
-            split_sub_themes = Config.get('print', {}).get('split_sub_themes', False)
             if split_sub_themes:
                 if 'SubTheme' in restriction_on_landownership:
                     theme = theme + '_' + restriction_on_landownership['SubTheme']
-                    restriction_on_landownership['SubTheme_Text'] = restriction_on_landownership['SubTheme']
+                    restriction_on_landownership['Split_SubTheme'] = True
 
             geom_type = \
                 'AreaShare' if 'AreaShare' in restriction_on_landownership else \

--- a/pyramid_oereb/standard/pyramid_oereb.yml.mako
+++ b/pyramid_oereb/standard/pyramid_oereb.yml.mako
@@ -85,6 +85,9 @@ pyramid_oereb:
     # Whether to display the RealEstate_SubunitOfLandRegister (Grundbuchkreis) in the pdf extract or not.
     # Default to true.
     display_real_estate_subunit_of_land_register: true
+    # Split themes up, so that each sub theme gets its own page
+    # Disabled by default.
+    split_sub_themes: false
 
   # The "app_schema" property contains only one sub property "name". This is directly related to the database
   # creation process, because this name is used as schema name in the target database. The app_schema holds


### PR DESCRIPTION
If `split_sub_themes` is enabled, each subtheme will get a separate page in the pdf output.
Per default, this behaviour is disabled and should not affect anyone even if they have values in the subtheme field.