### PR TITLE
manual update of deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ pyramid-debugtoolbar==4.5
 PyYAML==3.13
 shapely==1.6.4.post1  # rq.filter: ==1.6.4.post1
 simplejson==3.16.0
-SQLAlchemy==1.2.14
-sqlalchemy-utils==0.33.6
+SQLAlchemy==1.2.15
+sqlalchemy-utils==0.33.9
 transaction==2.4.0
 urllib3[secure]==1.24.1
 waitress==1.1.0
@@ -15,8 +15,8 @@ zope.sqlalchemy==1.0
 jsonschema==2.6.0
 pyreproj==1.0.0
 lxml==4.2.5
-generateDS==2.29.24
-requests==2.20.1
+generateDS==2.30.8
+requests==2.21.0
 geolink-formatter==1.3.1
 pyconizer==0.1.4
 tqdm==4.28.1


### PR DESCRIPTION
manual update of deps, without pytest update which needs to be evaluated separately. Update is necessary because of new idna version on pypi, which in turn requires us to use new version of requests library to be compatible.