### PR TITLE
Cleanup tests to remove warnings + update to pytest 4

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-pytest==3.10.1 # rq.filter: < 4
+pytest==4.0.2
 pytest-cov==2.6.0
-pytest-ordering==0.5 # rq.filter: <= 0.5
+pytest-ordering==0.6
 pyflakes==2.0.0
 flake8==3.6.0
 pycodestyle==2.4.0

--- a/tests/contrib/print_proxy/test_mapfish_print.py
+++ b/tests/contrib/print_proxy/test_mapfish_print.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 import json
 import codecs
-import pytest
 from pyramid_oereb.contrib.print_proxy.mapfish_print import Renderer
 from tests.renderer import DummyRenderInfo
 
 
-@pytest.fixture()
 def coordinates():
     return [[[
         [2615122.772, 1266688.951], [2615119.443, 1266687.783], [2615116.098, 1266686.662],
@@ -16,7 +14,6 @@ def coordinates():
     ]]]
 
 
-@pytest.fixture()
 def extract():
     with codecs.open(
             'tests/contrib/print_proxy/resources/test_extract.json'
@@ -24,7 +21,6 @@ def extract():
         return json.loads(f.read())
 
 
-@pytest.fixture()
 def expected_printable_extract():
     with codecs.open(
             'tests/contrib/print_proxy/resources/expected_getspec_extract.json'
@@ -32,7 +28,6 @@ def expected_printable_extract():
         return json.loads(f.read())
 
 
-@pytest.fixture()
 def geometry():
     return {
         'type': 'MultiPolygon',
@@ -40,7 +35,6 @@ def geometry():
     }
 
 
-@pytest.fixture()
 def getSameEntryInList(reference, objects):
     sameObject = None
 
@@ -71,7 +65,6 @@ def getSameEntryInList(reference, objects):
     return None
 
 
-@pytest.fixture()
 def deepCompare(value, valueToCompare, verbose=True):
     match = True
     # Go inside dict to compare values inside

--- a/tests/renderer/test_json.py
+++ b/tests/renderer/test_json.py
@@ -34,13 +34,17 @@ def law_status():
     return LawStatusRecord(u'inForce', {'de': u'In Kraft'})
 
 
-@pytest.fixture()
-def params():
+def default_param():
     return Parameter('reduced', 'json', False, False, 'BL0200002829', '1000', 'CH775979211712', 'de')
 
 
+@pytest.fixture()
+def params():
+    return default_param()
+
+
 @pytest.mark.parametrize('parameter', [
-    params(),
+    default_param(),
     Parameter('reduced', 'json', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de'),
     None
 ])
@@ -207,7 +211,7 @@ def test_format_real_estate(config):
 
 
 @pytest.mark.parametrize('parameter', [
-    params(),
+    default_param(),
     Parameter('reduced', 'json', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de'),
     Parameter('full', 'json', False, False, 'BL0200002829', '1000', 'CH775979211712', 'de')
 ])
@@ -489,7 +493,7 @@ def test_format_map(config, params):
 
 
 @pytest.mark.parametrize('parameter', [
-    params(),
+    default_param(),
     Parameter('reduced', 'json', False, True, 'BL0200002829', '1000', 'CH775979211712', 'de')
 ])
 def test_format_legend_entry(parameter, config):


### PR DESCRIPTION
Adresses #678 .

Fixes related to the @pytest.fixture() annotation are in the first commit.

Updating to pytest 4 removes the deprecation warnings.

On my machine, this runs without errors and warnings.