### PR TITLE
accept extra parameters

### DIFF
--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -1,4 +1,4 @@
-throwErrorOnExtraParameters: true
+throwErrorOnExtraParameters: false
 
 resourceBundle: Report
 


### PR DESCRIPTION
accept extra parameters: needed in more recent versions of mapfish-print, because DocumentType is part of the payload, but not used in the templates