### PR TITLE
Glossary display order 590

### DIFF
--- a/pyramid_oereb/lib/renderer/__init__.py
+++ b/pyramid_oereb/lib/renderer/__init__.py
@@ -154,30 +154,36 @@ class Base(object):
         Returns:
             new_text (str): The text value converted to lower case and striped of special characters.
         """
+        if text is None:
+            return ''
         new_text = text.lower() if sys.version_info.major > 2 else unicode(text.lower())
         return unicodedata.normalize('NFD', new_text)
 
-    def sort_by_localized_text(self, element_list):
+    def sort_by_localized_text(self, multilingual_elements, value_accessor):
         """
         Sort a list of translated text elements alphabetically.
 
         Args:
-            element_list (pyramid_oereb.lib.records.view_service): The list of map.legends to sort.
+            multilingual_elements (list of dict): A list of multilingual elements
+            or dict that contains multilingual elements.
+            value_accessor (function(dict)->string): A function to access the
+                text of a multilingual object to us to sort the list
 
         Returns:
-            list of pyramid_oereb.lib.records.view_service: Alphabetically and language specific sorted
-                elements if translations exist or the list of unsorted map.elements if soring failed.
+            list of dict: Alphabetically and language specific sorted elements
+                if translations exist or the list of unsorted element if
+                sorting failed.
 
         """
         try:
             # Sort the list only if translations exist.
             return sorted(
-                element_list,
-                key=lambda text_element: self.unaccent_lower(
-                    self.get_localized_text(text_element.legend_text)['Text']
+                multilingual_elements,
+                key=lambda element: self.unaccent_lower(
+                    self.get_localized_text(value_accessor(element))['Text']
                 )
             )
 
         except AttributeError as ex:
-            log.warn('Other legend can not be sorted: {0}'.format(ex))
-            return element_list
+            log.warn('Elements can not be sorted: {0}'.format(ex))
+            return multilingual_elements

--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -158,7 +158,9 @@ class Renderer(Base):
                     log.warning("glossary entry in requested language missing for title {}".format(gls.title))
 
             extract_dict['Glossary'] = glossaries
-
+        
+        # Sort glossary by requested language alphabetically
+        extract_dict['Glossary'].sort(key=lambda k: locale.strxfrm(k['Title'][0]['Text'].encode('utf-8')))
         log.debug("_render() done.")
         return extract_dict
 

--- a/pyramid_oereb/lib/renderer/extract/json_.py
+++ b/pyramid_oereb/lib/renderer/extract/json_.py
@@ -158,9 +158,12 @@ class Renderer(Base):
                     log.warning("glossary entry in requested language missing for title {}".format(gls.title))
 
             extract_dict['Glossary'] = glossaries
-        
+
         # Sort glossary by requested language alphabetically
-        extract_dict['Glossary'].sort(key=lambda k: locale.strxfrm(k['Title'][0]['Text'].encode('utf-8')))
+        extract_dict['Glossary'] = self.sort_by_localized_text(
+            extract_dict['Glossary'],
+            lambda element: element['Title'][0]['Text']
+        )
         log.debug("_render() done.")
         return extract_dict
 
@@ -487,7 +490,10 @@ class Renderer(Base):
         if map_.legend_at_web is not None:
             map_dict['LegendAtWeb'] = map_.legend_at_web
         if isinstance(map_.legends, list) and len(map_.legends) > 0:
-            other_legend = self.sort_by_localized_text(map_.legends)
+            other_legend = self.sort_by_localized_text(
+                map_.legends,
+                lambda element: element.legend_text
+            )
 
             map_dict['OtherLegend'] = [
                 self.format_legend_entry(legend_entry) for legend_entry in other_legend]

--- a/pyramid_oereb/lib/renderer/extract/templates/xml/extract.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/extract.xml
@@ -17,6 +17,12 @@
         else:
             return 'false'
 %>
+<%
+    def accessor(element):
+        return element.title
+
+    sorted_glossaries = sort_by_localized_text(extract.glossaries, accessor)
+%>
     %if params.flavour == 'embeddable':
     <embeddable>
         <cadasterState>${str(extract.embeddable.cadaster_state.strftime(date_format))}</cadasterState>
@@ -78,7 +84,7 @@
         <data:BaseData>
             <%include file="multilingual_m_text.xml" args="text=extract.base_data"/>
         </data:BaseData>
-        %for glossary in extract.glossaries:
+        %for glossary in sorted_glossaries:
         <%include file="glossary.xml" args="glossary=glossary"/>
         %endfor
         <%include file="real_estate.xml" args="real_estate=extract.real_estate"/>

--- a/pyramid_oereb/lib/renderer/extract/templates/xml/view_service.xml
+++ b/pyramid_oereb/lib/renderer/extract/templates/xml/view_service.xml
@@ -10,7 +10,8 @@
 %endif
 %if map.legends:
 <%
-    sorted_legends = sort_by_localized_text(map.legends)
+    accessor = lambda element: element.legend_text
+    sorted_legends = sort_by_localized_text(map.legends, accessor)
 %>
 %for legend_entry in sorted_legends:
 <data:OtherLegend>

--- a/tests/renderer/test_base.py
+++ b/tests/renderer/test_base.py
@@ -101,6 +101,60 @@ def test_get_multilingual_text_from_dict(language, result):
     assert ml_text[0].get('Text') == result
 
 
+def test_sort_by_localized_text():
+    renderer = Renderer(DummyRenderInfo())
+    renderer._language = 'de'
+    # Elements like in the glossary
+    multilingual_elements = [{
+        'title': {
+            'fr': u'RDPPF',
+            'de': u'\xd6REB',
+        },
+        'content': {
+            'fr': u'Content-RDPPF',
+            'de': u'Content-\xd6REB',
+        },
+    }, {
+        'title': {
+            'fr': u'No OFS',
+            'de': u'BFS-Nr.',
+        },
+        'content': {
+            'fr': u'Content-No OFS',
+            'de': u'Content-BFS-Nr.',
+        },
+    }, {
+        'title': {
+            'fr': u'Ofo',
+            'de': u'WaV',
+        },
+        'content': {
+            'fr': u'Content-Ofo',
+            'de': u'Content-WaV',
+        },
+    }]
+    sorted_multilingual_elements = renderer.sort_by_localized_text(
+            multilingual_elements,
+            lambda element: element['title']
+    )
+    assert isinstance(sorted_multilingual_elements, list)
+    assert len(sorted_multilingual_elements) == 3
+    # Elements sorted by 'de' title:
+    assert sorted_multilingual_elements[0]['title']['de'] == u'BFS-Nr.'
+    assert sorted_multilingual_elements[1]['title']['de'] == u'\xd6REB'
+    assert sorted_multilingual_elements[2]['title']['de'] == u'WaV'
+    assert sorted_multilingual_elements[0]['content']['de'] == u'Content-BFS-Nr.'
+    assert sorted_multilingual_elements[1]['content']['de'] == u'Content-\xd6REB'
+    assert sorted_multilingual_elements[2]['content']['de'] == u'Content-WaV'
+    # Still sorted with 'de' language, effect on 'fr' elements:
+    assert sorted_multilingual_elements[0]['title']['fr'] == u'No OFS'
+    assert sorted_multilingual_elements[1]['title']['fr'] == u'RDPPF'
+    assert sorted_multilingual_elements[2]['title']['fr'] == u'Ofo'
+    assert sorted_multilingual_elements[0]['content']['fr'] == u'Content-No OFS'
+    assert sorted_multilingual_elements[1]['content']['fr'] == u'Content-RDPPF'
+    assert sorted_multilingual_elements[2]['content']['fr'] == u'Content-Ofo'
+
+
 @pytest.mark.parametrize('theme_code', [
     u'ContaminatedSites',
     u'NotExistingTheme',


### PR DESCRIPTION
Fix #590 

Supersede #714 

Update current sort function to work generically and also with an objects like glossaries
See last commit (tests) to have a quick overview.

(Order will be A-Ä-B-C...O-Ö, P... Z)
