### PR TITLE
Update c2c libs

### DIFF
--- a/CONST_vars.yml
+++ b/CONST_vars.yml
@@ -1,7 +1,5 @@
 vars:
 
-  # No vars until now
-  dummy: dummy
   sqlalchemy_url: '{SQLALCHEMY_URL}'
   png_root_dir: '{PNG_ROOT_DIR}'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM camptocamp/c2cwsgiutils:0
+FROM camptocamp/c2cwsgiutils:2
 LABEL maintainer "info@camptocamp.org"
 
 WORKDIR /app
 
-RUN \
-    apt-get update && \
-    apt-get install --assume-yes --no-install-recommends pdftk && \
-    apt-get clean && \
-    rm --recursive --force /var/lib/apt/lists/*
+# The full pdf extract functionality requires pdftk, but this library is not available in Ubuntu bionic.
+# Note that it is expected that the full pdf extract functionality will be removed from the next
+# specification.
+#RUN \
+#    apt-get update && \
+#    apt-get install --assume-yes --no-install-recommends pdftk-java && \
+#    apt-get clean && \
+#    rm --recursive --force /var/lib/apt/lists/*
 
 COPY docker/requirements.txt /app/docker/
 COPY requirements.txt /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     build: .
     image: camptocamp/oereb-wsgi
     ports:
-    - 6543:80
+    - 6543:8080
     environment:
     - PRINT_SERVICE_HOST=print
     - PRINT_SERVICE_PORT=8080

--- a/print/print-apps/oereb/config.yaml
+++ b/print/print-apps/oereb/config.yaml
@@ -259,7 +259,7 @@ templates:
             httpProcessors:
             - !mapUri    # NEEDED FOR DOCKER ENVIRONMENT
                 mapping:
-                  (https?)://localhost:6543/(.*): "http://wsgi/$2"
+                  (https?)://localhost:6543/(.*): "http://wsgi:8080/$2"
             - !forwardHeaders
                 headers:
                 - Referer
@@ -267,7 +267,7 @@ templates:
                 matchers:
                 - !dnsMatch    # NEEDED FOR DOCKER ENVIRONMENT
                   host: wsgi
-                  port: 80
+                  port: 8080
                   reject: false
                 - !ipMatch
                   ip: 10.0.0.0


### PR DESCRIPTION
Update c2cwsgiutils
(note that c2ctemplate aka c2c.template can not be updated as long as python2 compatibility is required. New versions of c2ctemplate assume python3).