### PR TITLE
Add libffi to fix build and checks failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer "info@camptocamp.org"
 
 WORKDIR /app
 
-ARG DEV_PACKAGES="libgeos-c1v5 libpq-dev"
+ARG DEV_PACKAGES="libgeos-c1v5 libpq-dev libffi-dev"
 ARG PYTHON_DEV_PACKAGES="python3.7-dev build-essential"
 
 # The full pdf extract functionality requires pdftk, but this library is not available in Ubuntu bionic.

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && \
 
 COPY requirements.txt requirements-tests.txt /app/
 
-ARG DEV_PACKAGES="libgeos-c1v5 libpq-dev"
+ARG DEV_PACKAGES="libgeos-c1v5 libpq-dev libffi-dev"
 ARG PYTHON_TEST_VERSION
 ENV PYTHON_DEV_PACKAGE=${PYTHON_TEST_VERSION}-dev
 RUN apt update && \


### PR DESCRIPTION
Currently, the build a "plain vanilla" pyramid_oereb V1 based on a completely fresh c2cwsgiutils 3 fails.
Adding libffi seems to fix that.