### PR TITLE
Workaround fixing max version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 69.5.1",
+    "setuptools >= 69.5.1, <81",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 69.5.1, <81",
+    "setuptools >= 69.5.1",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ authors = [
 ]
 keywords = ["pyramid oereb"]
 readme = "README.rst"
+dependencies = [
+    "setuptools >= 69.5.1, <81"
+]
 
 [project.urls]
 Repository = "https://github.com/openoereb/pyramid_oereb"


### PR DESCRIPTION
Normally this should temporarily fix the installation issues seen in CI.

```
.venv/lib/python3.13/site-packages/pyramid/asset.py:2: in <module>
    import pkg_resources
E   ModuleNotFoundError: No module named 'pkg_resources'
```

for info: import of pkg_resources has following warning:
```
>>> import pkg_resources
<stdin>:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```