### PR TITLE
2191 getegrid   postalcode localisation number optional

### DIFF
--- a/pyramid_oereb/contrib/data_sources/standard/sources/address.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/address.py
@@ -1,40 +1,52 @@
 # -*- coding: utf-8 -*-
 from geoalchemy2.elements import _SpatialElement
 from geoalchemy2.shape import to_shape
+from sqlalchemy.orm import Query, Session
 from sqlalchemy.orm.exc import NoResultFound
 
+from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources import BaseDatabaseSource
 from pyramid_oereb.core.sources.address import AddressBaseSource
+from pyramid_oereb.core.views.webservice import Parameter
 
 
 class DatabaseSource(BaseDatabaseSource, AddressBaseSource):
 
-    def read(self, params, street_name, zip_code, street_number):
+    def read(self, params: Parameter, street_name: str, zip_code: int, street_number: str | None = None) \
+            -> list[AddressRecord]:
         """
-        The read method to access the standard database structure. It uses SQL-Alchemy for querying. It tries
-        to find the items via passed arguments.
+        The read method for accessing the standard database schema.
+        It uses SQLAlchemy to query the database for records matching the supplied arguments.
 
         Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-            street_name (unicode): The name of the street for the desired address.
-            zip_code (int): The postal zipcode for the desired address.
-            street_number (str): The house or so called street number of the desired address.
+            params (pyramid_oereb.core.views.webservice.Parameter):
+                The parameters of the extract request
+            street_name (str):
+                The name of the street
+            zip_code (int):
+                The postal code
+            street_number (str | None):
+                The house or street number
 
         Returns:
-            list of pyramid_oereb.core.records.address.AddressRecord: The list of address records.
+            list[pyramid_oereb.core.records.address.AddressRecord]:
+                A list of address records matching the supplied search criteria.
         """
-        session = self._adapter_.get_session(self._key_)
+        session: Session = self._adapter_.get_session(self._key_)
         try:
-            query = session.query(self._model_)
-            results = [query.filter(
+            query: Query = session.query(self._model_)
+            query = query.filter(
                 self._model_.street_name == street_name
             ).filter(
                 self._model_.zip_code == zip_code
-            ).filter(
-                self._model_.street_number == street_number
-            ).one()]
+            )
 
-            records = []
+            if street_number is not None:
+                query = query.filter(self._model_.street_number == street_number)
+
+            results: list = query.all()
+
+            records: list[AddressRecord] = []
             for result in results:
                 records.append(self._record_class_(
                     result.street_name,

--- a/pyramid_oereb/contrib/data_sources/standard/sources/address.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/address.py
@@ -8,6 +8,7 @@ from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources import BaseDatabaseSource
 from pyramid_oereb.core.sources.address import AddressBaseSource
 
+
 class DatabaseSource(BaseDatabaseSource, AddressBaseSource):
 
     def read(self, params, street_name: str, zip_code: int, street_number: str | None = None) \

--- a/pyramid_oereb/contrib/data_sources/standard/sources/address.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/address.py
@@ -7,12 +7,10 @@ from sqlalchemy.orm.exc import NoResultFound
 from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources import BaseDatabaseSource
 from pyramid_oereb.core.sources.address import AddressBaseSource
-from pyramid_oereb.core.views.webservice import Parameter
-
 
 class DatabaseSource(BaseDatabaseSource, AddressBaseSource):
 
-    def read(self, params: Parameter, street_name: str, zip_code: int, street_number: str | None = None) \
+    def read(self, params, street_name: str, zip_code: int, street_number: str | None = None) \
             -> list[AddressRecord]:
         """
         The read method for accessing the standard database schema.
@@ -44,7 +42,7 @@ class DatabaseSource(BaseDatabaseSource, AddressBaseSource):
             if street_number is not None:
                 query = query.filter(self._model_.street_number == street_number)
 
-            results: list = query.all()
+            results: list = [query.one()]
 
             records: list[AddressRecord] = []
             for result in results:

--- a/pyramid_oereb/contrib/data_sources/standard/sources/address.py
+++ b/pyramid_oereb/contrib/data_sources/standard/sources/address.py
@@ -43,7 +43,7 @@ class DatabaseSource(BaseDatabaseSource, AddressBaseSource):
             if street_number is not None:
                 query = query.filter(self._model_.street_number == street_number)
 
-            results: list = [query.one()]
+            results: list = query.all()
 
             records: list[AddressRecord] = []
             for result in results:

--- a/pyramid_oereb/contrib/data_sources/swisstopo/address.py
+++ b/pyramid_oereb/contrib/data_sources/swisstopo/address.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 import requests
 from pyreproj import Reprojector
+from requests import Response
 from shapely.geometry import Point
 
 from pyramid_oereb import Config
 from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources.address import AddressBaseSource
+from pyramid_oereb.core.views.webservice import Parameter
 
 
 class AddressGeoAdminSource(AddressBaseSource):
@@ -26,9 +28,10 @@ class AddressGeoAdminSource(AddressBaseSource):
         super(AddressGeoAdminSource, self).__init__()
         self._geoadmin_url = kwargs.get('geoadmin_search_api',
                                         'https://api3.geo.admin.ch/rest/services/api/SearchServer')
-        self._type = 'locations'
+        self._type: str = 'locations'
         self._proxies = kwargs.get('proxies')
         self._referer = kwargs.get('referer', None)
+        self._origins: str | None = None
         if 'origins' in kwargs:
             origins = kwargs.get('origins')
             if isinstance(origins, list):
@@ -37,30 +40,36 @@ class AddressGeoAdminSource(AddressBaseSource):
         else:
             self._origins = 'address'
 
-    def read(self, params, street_name, zip_code, street_number):
+    def read(self, params: Parameter, street_name: str, zip_code:int, street_number: str | None = None) \
+            -> list[AddressRecord]:
         """
         Queries an address using the federal GeoAdmin API location search.
 
         Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-            street_name (unicode): The name of the street for the desired address.
-            zip_code (int): The postal zipcode for the desired address.
-            street_number (unicode): The house or so called street number of the desired address.
+            params (pyramid_oereb.core.views.webservice.Parameter):
+                The parameters of the extract request
+            street_name (str):
+                The name of the street
+            zip_code (int):
+                The postal code
+            street_number (str | None):
+                The house or street number
 
         Returns:
-            list of pyramid_oereb.core.records.address.AddressRecord: The list of address records.
+            list[pyramid_oereb.core.records.address.AddressRecord]:
+                A list of address records matching the supplied search criteria.
         """
-        headers = {}
+        headers: dict[str, str | None] = {}
         if self._referer is not None:
             headers.update({
                 'Referer': self._referer
             })
-        request_params = {
+        request_params: dict[str, str | None] = {
             'type': self._type,
             'origins': self._origins,
-            'searchText': u'{0} {1} {2}'.format(zip_code, street_name, street_number)
+            'searchText': f'{zip_code} {street_name} {street_number}'
         }
-        response = requests.get(
+        response: Response = requests.get(
             self._geoadmin_url,
             params=request_params,
             proxies=self._proxies,
@@ -68,9 +77,9 @@ class AddressGeoAdminSource(AddressBaseSource):
             timeout=4
         )
         if response.status_code == requests.codes.ok:
-            rp = Reprojector()
-            srid = Config.get('srid')
-            records = []
+            rp: Reprojector = Reprojector()
+            srid: int = Config.get('srid')
+            records: list[AddressRecord] = []
             data = response.json()
             if 'results' in data:
                 for item in data.get('results'):

--- a/pyramid_oereb/contrib/data_sources/swisstopo/address.py
+++ b/pyramid_oereb/contrib/data_sources/swisstopo/address.py
@@ -8,6 +8,7 @@ from pyramid_oereb import Config
 from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources.address import AddressBaseSource
 
+
 class AddressGeoAdminSource(AddressBaseSource):
     """
     An address source that uses the federal GeoAdmin API to return the geo location of a postal address.
@@ -38,7 +39,7 @@ class AddressGeoAdminSource(AddressBaseSource):
         else:
             self._origins = 'address'
 
-    def read(self, params, street_name: str, zip_code:int, street_number: str | None = None) \
+    def read(self, params, street_name: str, zip_code: int, street_number: str | None = None) \
             -> list[AddressRecord]:
         """
         Queries an address using the federal GeoAdmin API location search.

--- a/pyramid_oereb/contrib/data_sources/swisstopo/address.py
+++ b/pyramid_oereb/contrib/data_sources/swisstopo/address.py
@@ -7,8 +7,6 @@ from shapely.geometry import Point
 from pyramid_oereb import Config
 from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources.address import AddressBaseSource
-from pyramid_oereb.core.views.webservice import Parameter
-
 
 class AddressGeoAdminSource(AddressBaseSource):
     """
@@ -40,7 +38,7 @@ class AddressGeoAdminSource(AddressBaseSource):
         else:
             self._origins = 'address'
 
-    def read(self, params: Parameter, street_name: str, zip_code:int, street_number: str | None = None) \
+    def read(self, params, street_name: str, zip_code:int, street_number: str | None = None) \
             -> list[AddressRecord]:
         """
         Queries an address using the federal GeoAdmin API location search.

--- a/pyramid_oereb/core/readers/address.py
+++ b/pyramid_oereb/core/readers/address.py
@@ -1,47 +1,59 @@
 # -*- coding: utf-8 -*-
 from pyramid.path import DottedNameResolver
 
+from pyramid_oereb.core.records.address import AddressRecord
+from pyramid_oereb.core.sources.address import AddressBaseSource
+from pyramid_oereb.core.views.webservice import Parameter
+
 
 class AddressReader(object):
     """
-    The central reader accessor for addresses. It is directly bound to a so called source which is defined by
-    a pythonic dotted string to the class definition of this source. An instance of the passed source will be
-    created on instantiation of this reader class by passing through the parameter kwargs.
+    The central access point for reading addresses. It delegates all operations to a source
+    implementation defined by a Python dotted import path. When this reader is instantiated,
+    an instance of the defined source class is created as well, with all
+    `**kwargs` passed to its constructor.
 
-    The address is here the real combination of a street name, a zip code and a street number.
+    The address is a combination of a street name, a zip code, and optionally a street number.
     """
 
-    def __init__(self, dotted_source_class_path, **params):
+    def __init__(self, dotted_source_class_path: str | AddressBaseSource, **params):
         """
         Args:
-            dotted_source_class_path (str or pyramid_oereb.lib.sources.address.AddressBaseSource):
-                The path to the class which represents the source used by this reader. This
-                class must exist and it must implement basic source behaviour of the
-                :ref:`api-pyramid_oereb-core-sources-address-addressbasesource`.
-            (kwargs): kwargs, which are necessary as configuration parameter for the above by
-                dotted name defined class.
+            dotted_source_class_path (str or pyramid_oereb.core.readers.address.AddressBaseSource):
+                The path to the class representing the source used by this reader. The
+                class must exist and implement the basic source behavior of the
+                `pyramid_oereb.core.readers.address.AddressBaseSource`.
+            params:
+                kwrgs forwarded to the constructor of the configured source class.
         """
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self, params, street_name, zip_code, street_number):
+    def read(self, params: Parameter, street_name: str, zip_code: int, street_number: str | None = None) \
+            -> list[AddressRecord]:
         """
-        The read method of this reader. There we invoke the read method of the bound source.
+        Reads addresses from the configured source matching the supplied criteria.
+
+        The method delegates the lookup of the addresses to the configured source implementation.
 
         Note:
-            If you subclass this class your implementation needs to offer this method in the same
-            signature. Means the parameters must be the same and the return must be a list of
-            :ref:`api-pyramid_oereb-core-records-address-addressrecord`. Otherwise the API like way the server
-            works would be broken.
+            Subclasses must implement this method with the same signature and return
+            a list of `pyramid_oereb.core.records.address.AddressRecord` objects.
+            Changing the signature or return type breaks the public API contract.
 
         Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-            street_name (unicode): The name of the street for the desired address.
-            zip_code (int): The postal zipcode for the desired address.
-            street_number (str): The house or so called street number of the desired address.
+            params (pyramid_oereb.core.views.webservice.Parameter):
+                The parameters of the extract request
+            street_name (str):
+                The name of the street
+            zip_code (int):
+                The postal code
+            street_number (str | None):
+                The house or street number. If omitted, all addresses matching the street name
+                and postal code are returned.
 
         Returns:
-            list of pyramid_oereb.core.records.address.AddressRecord:
-                The list of found records filtered by the passed criteria.
+            list[pyramid_oereb.core.records.address.AddressRecord]:
+                A list of address records matching the supplied search criteria.
         """
         return self._source_.read(params, street_name, zip_code, street_number)

--- a/pyramid_oereb/core/readers/address.py
+++ b/pyramid_oereb/core/readers/address.py
@@ -3,8 +3,6 @@ from pyramid.path import DottedNameResolver
 
 from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources.address import AddressBaseSource
-from pyramid_oereb.core.views.webservice import Parameter
-
 
 class AddressReader(object):
     """
@@ -29,7 +27,7 @@ class AddressReader(object):
         source_class = DottedNameResolver().maybe_resolve(dotted_source_class_path)
         self._source_ = source_class(**params)
 
-    def read(self, params: Parameter, street_name: str, zip_code: int, street_number: str | None = None) \
+    def read(self, params, street_name: str, zip_code: int, street_number: str | None = None) \
             -> list[AddressRecord]:
         """
         Reads addresses from the configured source matching the supplied criteria.

--- a/pyramid_oereb/core/readers/address.py
+++ b/pyramid_oereb/core/readers/address.py
@@ -4,6 +4,7 @@ from pyramid.path import DottedNameResolver
 from pyramid_oereb.core.records.address import AddressRecord
 from pyramid_oereb.core.sources.address import AddressBaseSource
 
+
 class AddressReader(object):
     """
     The central access point for reading addresses. It delegates all operations to a source

--- a/pyramid_oereb/core/sources/address.py
+++ b/pyramid_oereb/core/sources/address.py
@@ -2,6 +2,7 @@
 
 from pyramid_oereb.core.sources import Base
 from pyramid_oereb.core.records.address import AddressRecord
+from pyramid_oereb.core.views.webservice import Parameter
 
 
 class AddressBaseSource(Base):
@@ -10,15 +11,21 @@ class AddressBaseSource(Base):
     """
     _record_class_ = AddressRecord
 
-    def read(self, params, street_name, zip_code, street_number):
+    def read(self, params: Parameter, street_name: str, zip_code: int, street_number:str | None = None):
         """
-        Every address source has to implement a read method. This method must accept the three parameters. If
-        you want adapt to your own source for addresses, this is the point where to hook in.
+        Every address source must implement a read method with the same signature.
+        To integrate a custom address source, implement this method in your source class.
+
+        The method reads addresses from the configured source matching the supplied criteria.
 
         Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameters of the extract request.
-            street_name (unicode): The name of the street for the desired address.
-            zip_code (int): The postal zipcode for the desired address.
-            street_number (str): The house or so called street number of the desired address.
+            params (pyramid_oereb.core.views.webservice.Parameter):
+                The parameters of the extract request
+            street_name (str):
+                The name of the street
+            zip_code (int):
+                The postal code
+            street_number (str | None):
+                The house or street number
         """
         pass  # pragma: no cover

--- a/pyramid_oereb/core/sources/address.py
+++ b/pyramid_oereb/core/sources/address.py
@@ -3,13 +3,14 @@
 from pyramid_oereb.core.sources import Base
 from pyramid_oereb.core.records.address import AddressRecord
 
+
 class AddressBaseSource(Base):
     """
     Base class for address sources.
     """
     _record_class_ = AddressRecord
 
-    def read(self, params, street_name: str, zip_code: int, street_number:str | None = None):
+    def read(self, params, street_name: str, zip_code: int, street_number: str | None = None):
         """
         Every address source must implement a read method with the same signature.
         To integrate a custom address source, implement this method in your source class.

--- a/pyramid_oereb/core/sources/address.py
+++ b/pyramid_oereb/core/sources/address.py
@@ -2,8 +2,6 @@
 
 from pyramid_oereb.core.sources import Base
 from pyramid_oereb.core.records.address import AddressRecord
-from pyramid_oereb.core.views.webservice import Parameter
-
 
 class AddressBaseSource(Base):
     """
@@ -11,7 +9,7 @@ class AddressBaseSource(Base):
     """
     _record_class_ = AddressRecord
 
-    def read(self, params: Parameter, street_name: str, zip_code: int, street_number:str | None = None):
+    def read(self, params, street_name: str, zip_code: int, street_number:str | None = None):
         """
         Every address source must implement a read method with the same signature.
         To integrate a custom address source, implement this method in your source class.

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -239,7 +239,7 @@ class PlrWebservice(object):
         """
         postalcode: str = str(self._params.get('POSTALCODE'))
         localisation: str = str(self._params.get('LOCALISATION'))
-        number: str | None = str(self._params.get('NUMBER'))
+        number: str | None = self._params.get('NUMBER')
         if not (postalcode and localisation):
             raise HTTPBadRequest(
                 'Both the POSTALCODE and the LOCALISATION must be provided for querying EGRIDs by address.'

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
-# import yappi
 import qrcode
 import io
-# import re
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPSeeOther, HTTPInternalServerError, HTTPNoContent, \
     HTTPNotFound
@@ -16,8 +14,10 @@ from pyramid_oereb import route_prefix
 from pyramid_oereb import Config
 from pyreproj import Reprojector
 
-from pyramid_oereb.core.processor import create_processor
+from pyramid_oereb.core.processor import create_processor, Processor
 from pyramid_oereb.core.readers.address import AddressReader
+from pyramid_oereb.core.records.address import AddressRecord
+from pyramid_oereb.core.records.real_estate import RealEstateRecord
 from pyramid_oereb.core.renderer import Base as Renderer
 from timeit import default_timer as timer
 
@@ -145,7 +145,7 @@ class PlrWebservice(object):
                 service = 'GetEgridIdent'
                 records = self._get_egrid_ident(params)
             # Type C
-            elif self.__has_params__(['POSTALCODE', 'LOCALISATION', 'NUMBER']):
+            elif self.__has_params__(['POSTALCODE', 'LOCALISATION']):
                 service = 'GetEgridAddress'
                 records = self._get_egrid_address(params)
             # Type D
@@ -156,7 +156,7 @@ class PlrWebservice(object):
             else:
                 raise HTTPBadRequest(
                     'Invalid parameters. You need one of the following combinations: '
-                    'EN or GNSS or IDENTDN and NUMBER or POSTALCODE, LOCALISATION and NUMBER.'
+                    'EN or GNSS or IDENTDN and NUMBER or POSTALCODE and LOCALISATION.'
                 )
             response = self.__get_egrid_response__(records, params)
         except HTTPNoContent as err:
@@ -225,36 +225,38 @@ class PlrWebservice(object):
         else:
             raise HTTPBadRequest('IDENTDN and NUMBER must be defined.')
 
-    def _get_egrid_address(self, params):
+    def _get_egrid_address(self, params: Parameter) -> list[RealEstateRecord]:
         """
-        Returns a list with the matched EGRIDs for the given postal address.
+        Searches EGRIDs by querying the data source with the given postal address.
 
         Args:
-            params (pyramid_oereb.views.webservice.Parameter): The parameter object.
+            params (pyramid_oereb.core.views.webservice.Parameter):
+                The parameter object.
 
         Returns:
-            list of pyramid_oereb.core.records.real_estate.RealEstateRecord:
-                The list of all found records filtered by the passed criteria.
+            list[pyramid_oereb.core.records.real_estate.RealEstateRecord]:
+                A list of real estate records matching the supplied search criteria.
         """
-        postalcode = self._params.get('POSTALCODE')
-        localisation = self._params.get('LOCALISATION')
-        number = self._params.get('NUMBER')
-        if postalcode and localisation and number:
-            reader = AddressReader(
-                Config.get_address_config().get('source').get('class'),
-                **Config.get_address_config().get('source').get('params')
+        postalcode: str = str(self._params.get('POSTALCODE'))
+        localisation: str = str(self._params.get('LOCALISATION'))
+        number: str | None = str(self._params.get('NUMBER'))
+        if not (postalcode and localisation):
+            raise HTTPBadRequest(
+                'Both the POSTALCODE and the LOCALISATION must be provided for querying EGRIDs by address.'
             )
-            addresses = reader.read(params, localisation, int(postalcode), number)
-            if len(addresses) == 0:
-                raise HTTPNoContent()
-            geometry = 'SRID={srid};{wkt}'.format(
-                srid=Config.get('srid'),
-                wkt=addresses[0].geom.wkt
-            )
-            processor = create_processor(real_estate_only=True)
-            return processor.real_estate_reader.read(params, **{'geometry': geometry})
-        else:
-            raise HTTPBadRequest('POSTALCODE, LOCALISATION and NUMBER must be defined.')
+        address_reader: AddressReader = AddressReader(
+            Config.get_address_config().get('source').get('class'),
+            **Config.get_address_config().get('source').get('params')
+        )
+        addresses: list[AddressRecord] = address_reader.read(params, localisation, int(postalcode), number)
+        if not addresses:
+            raise HTTPNoContent()
+        wkt_geometry: str = 'SRID={srid};{wkt}'.format(
+            srid=Config.get('srid'),
+            wkt=addresses[0].geom.wkt
+        )
+        processor: Processor = create_processor(real_estate_only=True)
+        return processor.real_estate_reader.read(params, **{'geometry': wkt_geometry})
 
     def get_extract_by_id(self):
         """
@@ -430,7 +432,7 @@ class PlrWebservice(object):
         Get format in the url and validate that it's one accepted.
 
         Args:
-            accepted_formats (list): A list of accepted format (str).
+            accepted_formats (list): A list of accepted formats (str).
 
         Returns:
             str: The validated format parameter.
@@ -572,20 +574,20 @@ class PlrWebservice(object):
             raise HTTPBadRequest(
                 'The parameter GNSS has to be a comma-separated pair of coordinates.')
 
-        # Coordinates provided as "latitude,longitude"
+        # Coordinates provided as "latitude, longitude"
         return self.__coord_transform__(coords, 4326).buffer(1.0)
 
-    def __has_params__(self, needed):
+    def __has_params__(self, required: list[str]):
         """
-        Checks if the request contains all needed parameters.
+        Checks if the request contains all required parameters.
 
         Args:
-            needed (list of str): The parameters to check.
+            required (list of str): The parameters to check.
 
         Returns:
-            bool: True if all needed parameters are available, false otherwise.
+            bool: True if all required parameters are available, false otherwise.
         """
-        for p in needed:
+        for p in required:
             if p not in self._params:
                 return False
         return True

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -225,7 +225,7 @@ class PlrWebservice(object):
         else:
             raise HTTPBadRequest('IDENTDN and NUMBER must be defined.')
 
-    def _get_egrid_address(self, params: Parameter) -> list[RealEstateRecord]:
+    def _get_egrid_address(self, params) -> list[RealEstateRecord]:
         """
         Searches EGRIDs by querying the data source with the given postal address.
 

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -258,7 +258,10 @@ class PlrWebservice(object):
                 srid=Config.get('srid'),
                 wkt=address.geom.wkt
             )
-            real_estate_records.extend(processor.real_estate_reader.read(params, **{'geometry': wkt_geometry}))
+            real_estate_records.extend(processor.real_estate_reader.read(
+                params,
+                **{'geometry': wkt_geometry})
+            )
 
         return real_estate_records
 

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -252,7 +252,7 @@ class PlrWebservice(object):
         if not addresses:
             raise HTTPNoContent()
         processor: Processor = create_processor(real_estate_only=True)
-        real_estate_records = []
+        real_estate_records: list[RealEstateRecord] = []
         for address in addresses:
             wkt_geometry: str = 'SRID={srid};{wkt}'.format(
                 srid=Config.get('srid'),

--- a/pyramid_oereb/core/views/webservice.py
+++ b/pyramid_oereb/core/views/webservice.py
@@ -251,12 +251,16 @@ class PlrWebservice(object):
         addresses: list[AddressRecord] = address_reader.read(params, localisation, int(postalcode), number)
         if not addresses:
             raise HTTPNoContent()
-        wkt_geometry: str = 'SRID={srid};{wkt}'.format(
-            srid=Config.get('srid'),
-            wkt=addresses[0].geom.wkt
-        )
         processor: Processor = create_processor(real_estate_only=True)
-        return processor.real_estate_reader.read(params, **{'geometry': wkt_geometry})
+        real_estate_records = []
+        for address in addresses:
+            wkt_geometry: str = 'SRID={srid};{wkt}'.format(
+                srid=Config.get('srid'),
+                wkt=address.geom.wkt
+            )
+            real_estate_records.extend(processor.real_estate_reader.read(params, **{'geometry': wkt_geometry}))
+
+        return real_estate_records
 
     def get_extract_by_id(self):
         """

--- a/tests/core/webservice/test_getegrid.py
+++ b/tests/core/webservice/test_getegrid.py
@@ -172,6 +172,63 @@ def test_getegrid_address(pyramid_oereb_test_config, schema_json_extract, real_e
     assert response.get('GetEGRIDResponse')[0].get('identDN') == u'BLTEST'
 
 
+def test_getegrid_address_no_localisation(pyramid_oereb_test_config, schema_json_extract, real_estate_data, address,
+                          real_estate_types_test_data):
+    del pyramid_oereb_test_config
+
+    request = MockRequest(
+        current_route_url='http://example.com/oereb/getegrid/json/4410/test/10'
+    )
+
+    # Add params to matchdict as the view will do it for
+    # /getegrid/{format}/{postalcode}/{localisation}/{number}
+    request.matchdict.update({
+        'format': u'json'
+    })
+    request.params.update({
+        'POSTALCODE': u'4410',
+        'NUMBER': u'10'
+    })
+    webservice = PlrWebservice(request)
+    response = webservice.get_egrid()
+
+    assert isinstance(response, HTTPBadRequest)
+    assert response.detail == (
+        'Invalid parameters. You need one of the following combinations: '
+        'EN or GNSS or IDENTDN and NUMBER or POSTALCODE and LOCALISATION.'
+    )
+
+
+def test_getegrid_address_without_number(pyramid_oereb_test_config, schema_json_extract, real_estate_data,
+                                         address, real_estate_types_test_data):
+    del pyramid_oereb_test_config
+
+    request = MockRequest(
+        current_route_url='http://example.com/oereb/getegrid/json/4410/test'
+    )
+
+    # Add params to matchdict as the view will do it for
+    # /getegrid/{format}/{postalcode}/{localisation}
+    request.matchdict.update({
+        'format': u'json'
+    })
+    request.params.update({
+        'POSTALCODE': u'4410',
+        'LOCALISATION': u'test'
+    })
+
+    webservice = PlrWebservice(request)
+    response = webservice.get_egrid().json
+    Draft4Validator.check_schema(schema_json_extract)
+    validator = Draft4Validator(schema_json_extract)
+    validator.validate(response)
+    assert isinstance(response, dict)
+    assert response.get('GetEGRIDResponse') is not None
+    assert response.get('GetEGRIDResponse')[0].get('egrid') == u'TEST'
+    assert response.get('GetEGRIDResponse')[0].get('number') == u'1000'
+    assert response.get('GetEGRIDResponse')[0].get('identDN') == u'BLTEST'
+
+
 def test_get_egrid_response(pyramid_test_config, real_estate_types_test_data):
     del pyramid_test_config
 

--- a/tests/core/webservice/test_getegrid.py
+++ b/tests/core/webservice/test_getegrid.py
@@ -172,8 +172,8 @@ def test_getegrid_address(pyramid_oereb_test_config, schema_json_extract, real_e
     assert response.get('GetEGRIDResponse')[0].get('identDN') == u'BLTEST'
 
 
-def test_getegrid_address_no_localisation(pyramid_oereb_test_config, schema_json_extract, real_estate_data, address,
-                          real_estate_types_test_data):
+def test_getegrid_address_no_localisation(pyramid_oereb_test_config, schema_json_extract, real_estate_data,
+                                          address, real_estate_types_test_data):
     del pyramid_oereb_test_config
 
     request = MockRequest(

--- a/tests/core/webservice/test_getegrid.py
+++ b/tests/core/webservice/test_getegrid.py
@@ -187,6 +187,30 @@ def test_getegrid_address_no_localisation(pyramid_oereb_test_config, schema_json
     })
     request.params.update({
         'POSTALCODE': u'4410',
+        'LOCALISATION': u'test',
+        'NUMBER': u'100000'
+    })
+    webservice = PlrWebservice(request)
+    response = webservice.get_egrid()
+
+    assert isinstance(response, HTTPNoContent)
+
+
+def test_getegrid_address_no_content(pyramid_oereb_test_config, schema_json_extract, real_estate_data,
+                                     address, real_estate_types_test_data):
+    del pyramid_oereb_test_config
+
+    request = MockRequest(
+        current_route_url='http://example.com/oereb/getegrid/json/4410/test/10'
+    )
+
+    # Add params to matchdict as the view will do it for
+    # /getegrid/{format}/{postalcode}/{localisation}/{number}
+    request.matchdict.update({
+        'format': u'json'
+    })
+    request.params.update({
+        'POSTALCODE': u'4410',
         'NUMBER': u'10'
     })
     webservice = PlrWebservice(request)


### PR DESCRIPTION
This pull request makes the parameter `street_number` in the `get_egrid` method, specifically in the `_get_egrid_address` method of the `pyramid_oereb/core/views/webservice.py` optional.

Furthermore, it propagates this change to any concerned module.

At the same time, certain improvements regarding type annotation were made in order to make the code base more readable.