### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,13 @@
 name: CI
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
 
   lint:
     name: Check style (lint)
-    permissions:
-      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -18,8 +19,6 @@ jobs:
 
   gitattributes:
     name: Check style (git-attributes)
-    permissions:
-      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -32,7 +31,6 @@ jobs:
   test-py:
     name: Test Python
     permissions:
-      contents: read
       packages: write
       pull-requests: write
     runs-on: ubuntu-24.04
@@ -85,8 +83,6 @@ jobs:
 
   test-fed-data:
     name: Check federal data definitions
-    permissions:
-      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -103,8 +99,6 @@ jobs:
 
   doc:
     name: Make and deploy documentation
-    permissions:
-      contents: read
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
@@ -124,7 +118,6 @@ jobs:
   build-and-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     permissions:
-      contents: read
       packages: write
     runs-on: ubuntu-24.04
     needs: [lint, gitattributes]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ jobs:
 
   lint:
     name: Check style (lint)
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -16,6 +18,8 @@ jobs:
 
   gitattributes:
     name: Check style (git-attributes)
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -27,6 +31,10 @@ jobs:
 
   test-py:
     name: Test Python
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     services:
       # Label used to access the service container
@@ -77,6 +85,8 @@ jobs:
 
   test-fed-data:
     name: Check federal data definitions
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -93,6 +103,8 @@ jobs:
 
   doc:
     name: Make and deploy documentation
+    permissions:
+      contents: read
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     steps:
@@ -111,6 +123,9 @@ jobs:
 
   build-and-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-24.04
     needs: [lint, gitattributes]
     steps:

--- a/.github/workflows/daily_check.yaml
+++ b/.github/workflows/daily_check.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   test-fed-data:
     name: Check federal data definitions
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -22,6 +24,8 @@ jobs:
 
   test-py:
     name: Test Python
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     services:
       # Label used to access the service container

--- a/.github/workflows/daily_check.yaml
+++ b/.github/workflows/daily_check.yaml
@@ -1,4 +1,6 @@
 name: daily check
+permissions:
+  contents: read
 on:
   schedule:
     - cron: "30 04 * * *"
@@ -6,8 +8,6 @@ on:
 jobs:
   test-fed-data:
     name: Check federal data definitions
-    permissions:
-      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -24,8 +24,6 @@ jobs:
 
   test-py:
     name: Test Python
-    permissions:
-      contents: read
     runs-on: ubuntu-24.04
     services:
       # Label used to access the service container


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to explicitly specify the required permissions for each job, following the principle of least privilege.