### PR TITLE
Update `pypdf` to 6.13.3 and `urllib3` to 2.7.0 in optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Changelog = "https://github.com/openoereb/pyramid_oereb/blob/master/CHANGES.rst"
 [project.optional-dependencies]
 # Dependencies listed in "recommend" must be included in "no-version" without explicit version number
 recommend = [
-    "pypdf==6.10.2",
+    "pypdf==6.13.3",
     "filetype==1.2.0",
     "geoalchemy2==0.19.0",
     "pyramid==2.1",
@@ -49,7 +49,7 @@ recommend = [
     "shapely==2.1.2",
     "SQLAlchemy==2.0.49",
     "pyaml-env==1.2.2",
-    "urllib3==2.6.3",
+    "urllib3==2.7.0",
     "waitress==3.0.2",
     "pyreproj==3.0.0",
     "mako-render==0.1.0",


### PR DESCRIPTION
This PR addresses the vulnerabilities detected by the GitHub security alerts